### PR TITLE
Initial Split Into Modules, Bump PR Relating To Window Restore Fixes

### DIFF
--- a/click_helpers.py
+++ b/click_helpers.py
@@ -1,0 +1,49 @@
+import time
+import pyautogui as auto
+import python_imagesearch.imagesearch as imagesearch
+
+from screen_helpers import onscreen
+import generic_helpers
+
+def click_key(key, delay=.1):
+    auto.keyDown(key)
+    time.sleep(delay)
+    auto.keyUp(key)
+
+
+def click_left(delay=.1):
+    auto.mouseDown()
+    time.sleep(delay)
+    auto.mouseUp()
+
+
+def click_right(delay=.1):
+    auto.mouseDown(button='right')
+    time.sleep(delay)
+    auto.mouseUp(button='right')
+
+
+def click_to(path, precision=0.8, delay=.1):
+    if onscreen(path, precision):
+        auto.moveTo(imagesearch.imagesearch(path))
+        click_left(delay)
+    else:
+        print(f"Could not find '{path}', skipping")
+
+def click_to_multiple(images, conditional_func=None, delay=None):
+    for image in images:
+        try:
+            click_to(image)
+        except Exception:
+            print(f"Failed to click {image}")
+        if generic_helpers.is_var_number(delay):
+            time.sleep(delay)
+        if generic_helpers.is_var_function(conditional_func) and conditional_func():
+            return True
+    return False
+
+def search_to(path):
+    pos = imagesearch.imagesearch(path)
+    if onscreen(path):
+        auto.moveTo(pos)
+        return pos

--- a/constants.py
+++ b/constants.py
@@ -1,0 +1,103 @@
+CONSTANTS = {
+    "executables": {
+        "league": {
+            "client": "C:\Riot Games\League of Legends\LeagueClient.exe",
+            "client_ux": "C:\Riot Games\League of Legends\LeagueClientUx.exe",
+            "game": "C:\Riot Games\League of Legends\Game\League of Legends.exe",
+        },
+    },
+    "tft_logo": {
+        "base": "./captures/tft_logo.png",
+        "overshadowed": "./captures/tft_logo_overshadowed.png",
+    },
+    "client": {
+        "screenshot_location": "./screenshots/",
+        "pre_match": {
+            "quick_play": "./captures/buttons/quick_play.png",
+            "find_match": {
+                "base": "./captures/buttons/find_match.png",
+                "highlighted": "./captures/buttons/find_match_highlighted.png",
+                "original": "./captures/buttons/find_match_original.png",
+            }
+        },
+        "in_queue": {
+            "base": "./captures/buttons/in_queue.png",
+            "overshadowed": "./captures/buttons/in_queue_overshadowed.png",
+            "accept": "./captures/buttons/accept.png",
+        },
+        "death": "./captures/death.png",
+        "reconnect": "./captures/buttons/reconnect.png",
+        "post_game": {
+            "skip_waiting_for_stats": "./captures/buttons/skip_waiting_for_stats.png",
+            "play_again": "./captures/buttons/play_again.png",
+            "missions_ok": "./captures/buttons/missions_ok.png",
+        },
+    },
+    "game": {
+        "loading": "./captures/loading.png",
+        "exit_now": {
+            "base": "./captures/buttons/exit_now_base.png",
+            "highlighted": "./captures/buttons/exit_now_highlighted.png",
+        },
+        "settings": "./captures/buttons/settings.png",
+        "surrender": {
+            "surrender_1": "./captures/buttons/surrender_1.png",
+            "surrender_2": "./captures/buttons/surrender_2.png",
+        },
+        "gamelogic": {
+            "choose_one": "./captures/buttons/choose_one.png",
+            "reroll": "./captures/buttons/reroll.png",
+            "take_all": "./captures/buttons/take_all.png",
+            "timer_1": "./captures/timer_1.png",
+            "xp_buy": "./captures/buttons/xp_buy.png",
+        },
+        "gold": {
+            "0": "./captures/gold/0.png",
+            "1": "./captures/gold/1.png",
+            "2": "./captures/gold/2.png",
+            "3": "./captures/gold/3.png",
+            "4": "./captures/gold/4.png",
+            "5": "./captures/gold/5.png",
+            "6": "./captures/gold/6.png",
+        },
+        "round": {
+            "-4": "./captures/round/-4.png",
+            "1-": "./captures/round/1-.png",
+            "2-": "./captures/round/2-.png",
+            "1-1": "./captures/round/1-1.png",
+            "2-2": "./captures/round/2-2.png",
+            "2-3": "./captures/round/2-3.png",
+            "2-4": "./captures/round/2-4.png",
+            "2-5": "./captures/round/2-5.png",
+            "3-1": "./captures/round/3-1.png",
+            "3-2": "./captures/round/3-2.png",
+            "3-3": "./captures/round/3-3.png",
+            "3-4": "./captures/round/3-4.png",
+            "3-7": "./captures/round/3-7.png",
+            "4-6": "./captures/round/4-6.png",
+            "4-7": "./captures/round/4-7.png",
+            "6-5": "./captures/round/6-5.png",
+            "6-6": "./captures/round/6-6.png",
+        },
+        "trait": {
+            "astral": "./captures/trait/astral.png",
+            "bruiser": "./captures/trait/bruiser.png",
+            "chemtech": "./captures/trait/chemtech.png",
+            "dragonmancer": "./captures/trait/dragonmancer.png",
+            "jade": "./captures/trait/jade.png",
+            "mage": "./captures/trait/mage.png",
+            "scrap": "./captures/trait/scrap.png",
+        },
+    },
+}
+
+find_match_images = [
+    CONSTANTS['client']['pre_match']['find_match']['base'],
+    CONSTANTS['client']['pre_match']['find_match']['highlighted'],
+    CONSTANTS['client']['pre_match']['find_match']['original'],
+]
+
+exit_now_images = [
+    CONSTANTS['game']['exit_now']['base'],
+    CONSTANTS['game']['exit_now']['highlighted'],
+]

--- a/generic_helpers.py
+++ b/generic_helpers.py
@@ -1,0 +1,13 @@
+def is_var_number(var):
+    try:
+        return type(var) == int or type(var) == float
+    except:
+        pass
+    return False
+
+def is_var_function(var):
+    try:
+        return callable(var)
+    except:
+        pass
+    return False

--- a/screen_helpers.py
+++ b/screen_helpers.py
@@ -1,0 +1,30 @@
+import time
+import python_imagesearch.imagesearch as imagesearch
+
+def onscreen(path, precision=0.8):
+    return imagesearch.imagesearch(path, precision)[0] != -1
+
+def onscreen_multiple_any(paths, precision=0.8):
+    for path in paths:
+        if (imagesearch.imagesearch(path, precision)[0] != -1):
+            return True
+    return False
+
+def onscreen_region(path, x1, y1, x2, y2, precision=0.8):
+    return imagesearch.imagesearcharea(path, x1, y1, x2, y2, precision)[0] != -1
+
+def onscreen_region_numLoop(path, timesample, maxSamples, x1, y1, x2, y2, precision=0.8):
+    return imagesearch_region_numLoop(path, timesample, maxSamples, x1, y1, x2, y2, precision)[0] != -1
+
+# Via https://github.com/drov0/python-imagesearch/blob/master/python_imagesearch/imagesearch.py
+def imagesearch_region_numLoop(image, timesample, maxSamples, x1, y1, x2, y2, precision=0.8):
+    pos = imagesearch.imagesearcharea(image, x1, y1, x2, y2, precision)
+    count = 0
+
+    while pos[0] == -1:
+        time.sleep(timesample)
+        pos = imagesearch.imagesearcharea(image, x1, y1, x2, y2, precision)
+        count = count + 1
+        if count > maxSamples:
+            break
+    return pos

--- a/system_helpers.py
+++ b/system_helpers.py
@@ -1,0 +1,33 @@
+import win32gui
+import win32process
+import win32com.client
+
+import psutil
+
+def set_active_window(window_id):
+    # Try to account for every scenario
+    shell = win32com.client.Dispatch("WScript.Shell")
+    shell.SendKeys('%')
+    win32gui.BringWindowToTop(window_id)
+    win32gui.SetForegroundWindow(window_id)
+    win32gui.SetActiveWindow(window_id)
+
+def bring_window_to_forefront(window_title, path_to_verify=None):
+    hwnd = win32gui.FindWindowEx(0,0,0, window_title)
+    if (path_to_verify is not None):
+        _, pid = win32process.GetWindowThreadProcessId(hwnd)
+        path = psutil.Process(pid).exe()
+        if path != path_to_verify:
+            print(f"Failed to find process to bring to forefront:\n\t{path} != {path_to_verify}")
+            return
+    set_active_window(hwnd)
+
+def find_in_processes(executable_path):
+    for proc in psutil.process_iter():
+        try:
+            if (proc.exe() == executable_path):
+                return True
+        except Exception:
+            # Nothing, we don't care
+            continue
+    return False


### PR DESCRIPTION
![](https://media.giphy.com/media/jpLxYq1XxwIlSA6q3Q/giphy.gif)

## Description
This is an initial pass at splitting the monolithic single-file code into modules, breaking out into related categories

This also highlights a recent change I pushed directly to `master` which updates the post-game logic to bring the League client to the forefront, which fixes situations that the client would get stuck on the `Find Match` or `Play Again` screen even though it appeared to be the 'forefront' window and be 'active'. Just tested it out for the last 18 hours and it's worked even better than expected, requiring 0 human intervention this morning until now after running since last night