### PR TITLE
Add `keyboard` Requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ argparse==1.4.0
 pywin32==305
 pyinstaller==5.6.2
 pylint==2.15.5
+keyboard==0.13.5


### PR DESCRIPTION
![](https://media.giphy.com/media/3ohzdYJK1wAdPWVk88/giphy.gif)

## Description
Adds the missing `keyboard` requirement

Fixes https://github.com/Kyrluckechuck/tft-bot/issues/18