### PR TITLE
Build `main` On `push`, Creating PreRelease Releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,18 +14,7 @@ jobs:
         python-version: '3.10'
     - run: pip install -r requirements.txt
     - run: python installer.py
-    # - name: release
-    #   uses: actions/create-release@v1
-    #   id: create_release
-    #   with:
-    #     draft: false
-    #     prerelease: false
-    #     release_name: ${{ steps.version.outputs.version }}
-    #     tag_name: ${{ github.ref }}
-    #     body_path: CHANGELOG.md
-    #   env:
-    #     GITHUB_TOKEN: ${{ github.token }}
-    
+
     - name: Display structure of downloaded files
       run: ls -R
     - uses: xresloader/upload-to-github-release@main
@@ -33,8 +22,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         file: "dist/TFT Bot.exe"
-        # release_id: ${{ steps.create_release.outputs.id }}
-        # branches: "main;dev"
+        branches: "main;dev"
         verbose: true
         prerelease: true
-        draft: true
+        draft: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: Main CI
 on:
   push:
-    # branches:
-    #   - main
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: Main CI
+on:
+  push:
+    # branches:
+    #   - main
+
+jobs:
+  build:
+    runs-on: [windows-latest]
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+    - run: pip install -r requirements.txt
+    - run: python installer.py
+    # - name: release
+    #   uses: actions/create-release@v1
+    #   id: create_release
+    #   with:
+    #     draft: false
+    #     prerelease: false
+    #     release_name: ${{ steps.version.outputs.version }}
+    #     tag_name: ${{ github.ref }}
+    #     body_path: CHANGELOG.md
+    #   env:
+    #     GITHUB_TOKEN: ${{ github.token }}
+    
+    - name: Display structure of downloaded files
+      run: ls -R
+    - uses: xresloader/upload-to-github-release@main
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        file: "dist/TFT Bot.exe"
+        # release_id: ${{ steps.create_release.outputs.id }}
+        # branches: "main;dev"
+        verbose: true
+        prerelease: true
+        draft: true

--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ Some features of this bot:
   - If >= 1, attempt 3 champ purchases
     - After that, if >= 2, re-roll
 
+TODO (near future):
+- Update `README.md` to mention exectuables as the preferred way for users to use this
+ - This is pending further testing & verification
+- Add ability to load from config file of some sort so that verbose can be enabled without running via CLI
+
 Some features I hope to implement at some point:
 - Ability to work on any monitor and/or in Windowed mode (make clicking relative to window location), which would help in not needing to change your actual monitors resolution
 - Update LoL game & client executable "constants" to be detectable

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ On that note, if anyone has any suggestions / features they would like to see, p
 
 # Installation:
 
-* Install Python 3.8.3 from [here](https://www.python.org/downloads/), or the Windows Store
+* Install Python 3.10 from [here](https://www.python.org/downloads/), or the Windows Store
 * Navigate to your install directory using `cd` and run `pip install -r requirements.txt` in Command Prompt
 * Navigate to your install directory using `cd` and run `py tft.py` in Command Prompt
 * Follow the instructions in your terminal window! Get into a TFT lobby, have the created window visible on your screen, and press 'OK' to start the bot!


### PR DESCRIPTION
![](https://media.giphy.com/media/Rm1p7xp3Odl2o/giphy.gif)

## Description
- Update "official" Python version from `3.8.3` to `3.10`
- Add CI pipeline so that any `main` push will get built, but only `main` merges will get official releases
  - Assuming these builds are successful and work, they can be manually promoted from PreRelease, but this takes care of creating them (and makes it much easier for new users to test)

TODO (in future PR):
- Update `README.md` to mention this as the preferred way for users to use this
- Add ability to load from config file of some sort so that verbose can be enabled without running via CLI