### PR TITLE
Load From Settings File, With CLI Taking Precedence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,4 @@ dmypy.json
 
 screenshots/
 *.log
+bot_settings.ini

--- a/README.md
+++ b/README.md
@@ -42,11 +42,21 @@ For example:
 
 On that note, if anyone has any suggestions / features they would like to see, please feel free to suggest in an [issue](https://github.com/Kyrluckechuck/tft-bot/issues), or by submitting your own PR to this!
 
-# Usage
+# Usage / Settings
 
 * Adding the `--ffearly` argument will make it forfeit at the first opportunity
 * Adding the (`-v` or `--verbose`) argument will enable more verbose debug logging
   * To be updated further to actually utilize this setting, at present it just prints a statement saying it's enabled/disabled
+
+## Config Structure
+If you want to use frequent settings / "set it and forget it", you can do so by creating `bot-settings.ini` with the following structure:
+```ini
+[SETTINGS]
+Verbose = True
+ForfeitEarly = False
+```
+
+Any setting not specified will fall back on the default behaviour, though CLI settings will take highest precedence (overriding config settings).
 
 # Installation:
 

--- a/tft.py
+++ b/tft.py
@@ -10,6 +10,7 @@ import random
 import subprocess
 import sys
 import time
+import configparser
 
 import keyboard
 from printy import printy
@@ -589,20 +590,33 @@ def tft_bot_loop() -> None:
             time.sleep(5)
             continue
 
-def main():
-    """Entrypoint function to initialize most of the code.
+def load_settings():
+    """Load settings for the bot.
 
-    Parses command line arguments, sets up console settings, logging, and kicks of the main bot loop.
+    Any CLI-set settings take highest precedence, then falling back on config values, then to defaults.
     """
     global FF_EARLY, VERBOSE
+
+    config = configparser.ConfigParser()
+    config.read('bot_settings.ini')
+    config.getboolean('SETTINGS', 'Verbose', fallback=False)
+    config.getboolean('SETTINGS', 'ForfeitEarly', fallback=False)
 
     arg_parser = argparse.ArgumentParser(prog="TFT Bot")
     arg_parser.add_argument("--ffearly", action='store_true', help="If the game should be surrendered at first available time.")
     arg_parser.add_argument("-v", "--verbose", action="store_true", help="Increase output verbosity, mostly useful for debugging")
     parsed_args = arg_parser.parse_args()
 
-    FF_EARLY = parsed_args.ffearly
-    VERBOSE = parsed_args.verbose
+    FF_EARLY = parsed_args.ffearly or config.getboolean('SETTINGS', 'ForfeitEarly', fallback=False)
+    VERBOSE = parsed_args.verbose or config.getboolean('SETTINGS', 'Verbose', fallback=False)
+
+def main():
+    """Entrypoint function to initialize most of the code.
+
+    Parses command line arguments, sets up console settings, logging, and kicks of the main bot loop.
+    """
+    load_settings()
+
     logging_handlers = [logging.StreamHandler()]
     if VERBOSE:
         logging_handlers.append(logging.FileHandler("debug.log"))

--- a/tft.py
+++ b/tft.py
@@ -2,6 +2,7 @@
 The main TFT Bot code
 """
 import argparse
+import configparser
 from datetime import datetime
 import logging
 import os
@@ -10,7 +11,6 @@ import random
 import subprocess
 import sys
 import time
-import configparser
 
 import keyboard
 from printy import printy


### PR DESCRIPTION
![](https://media.giphy.com/media/1hMjJILpxoWpQad37L/giphy-downsized.gif)

## Description

Load settings from `bot_settings.ini`, though if specified on CLI those will take highest precedence.

This is mainly to allow me to not have to always run with `-v` for verbose, since generally unchanging when I'm developing. This config structure also makes it "easier" for using the executable as you can "set it and forget it".

Pretty basic for now, may be more useful in the future.