### PR TITLE
Update Release Process To Not Generate Tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,4 +32,4 @@ jobs:
         branches: "main;dev"
         verbose: true
         draft: true
-        tag_name: env.GITHUB_REF_NAME
+        tag_name: ${{ env.GITHUB_REF_NAME }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
-name: Main CI
+name: Generate Release
 
-on: [push]
+on:
+  push:
+    tags:
+      - '*'
 
 jobs:
   build:
@@ -28,5 +31,5 @@ jobs:
         file: "dist/TFT Bot.exe"
         branches: "main;dev"
         verbose: true
-        prerelease: true
-        draft: false
+        draft: true
+        tag_name: env.GITHUB_REF_NAME


### PR DESCRIPTION
![](https://media.giphy.com/media/w89ak63KNl0nJl80ig/giphy.gif)

## Description

Pre-releases & tags were being generated for every push to `main`, but I'd prefer to be able to batch them a little cleaner.

Manual tag creation isn't an issue, so let's go that route first.