### PR TITLE
Add Support For Manual League Install Directory Specification Via Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,23 @@ Some features of this bot:
 If you want to use frequent settings / "set it and forget it", you can do so by creating `bot-settings.ini` in the same directory as the python script or release executable with the following structure:
 ```ini
 [SETTINGS]
+; Enable verbose output to console
 Verbose = True
+; For most scenarios I do not recommend enabling ForfeitEarly, since if you're botting pass EXP you get the most from staying in matches longer.
 ForfeitEarly = False
+; In most scenarios the below setting should not be required
+OverrideInstallLocation = C:\Riot Games\League of Legends
 ```
 
 Any setting not specified will fall back on the default behaviour, though CLI settings will take highest precedence (overriding config settings).
+
+### *Advanced Setting Info*
+#### **Verbose**
+Enable verbose logging to the console window.
+#### **ForfeitEarly**
+Forfeit at first opportunity instead of playing it out until eliminated.
+#### **OverrideInstallLocation**
+Override any League client detection logic. This should be set to whichever directory contains your `LeagueClient.exe`, `LeagueClientUx.exe`, and `Game\League of Legends.exe` executables, which is especially useful for Garena players as I can not automate this detection (from what I've heard).
 
 # Installation (for source):
 

--- a/system_helpers.py
+++ b/system_helpers.py
@@ -133,23 +133,31 @@ def expand_environment_variables(var: str) -> str:
     """
     return os.path.expandvars(var)
 
-def determine_league_install_location() -> str:
+def determine_league_install_location(override_path: str | None=None) -> str:
     """Determine the location League was installed.
+
+    Args:
+        override_path (str): A path to override any client detection logic.
 
     Returns:
         str: If successful, the determined install location. If unsuccessful, the default install location.
     """
     # Assign default just in case it failed to be found
     league_path = r"C:\Riot Games\League of Legends"
-    try:
-        access_registry = winreg.ConnectRegistry(None,winreg.HKEY_CURRENT_USER)
-        access_key = winreg.OpenKey(
-            access_registry, r'SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Riot Game league_of_legends.live', 0, winreg.KEY_READ
-        )
-        [league_path, _] = winreg.QueryValueEx(access_key, "InstallLocation")
-    except Exception as err:
-        logging.error(f'Could not dynamically determine League install location : {str(err)}')
-        logging.error(sys.exc_info())
+
+    if override_path is not None:
+        logging.warning(f'Override path supplied, using \'{override_path}\' as League install directory.')
+        league_path = override_path
+    else:
+        try:
+            access_registry = winreg.ConnectRegistry(None,winreg.HKEY_CURRENT_USER)
+            access_key = winreg.OpenKey(
+                access_registry, r'SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Riot Game league_of_legends.live', 0, winreg.KEY_READ
+            )
+            [league_path, _] = winreg.QueryValueEx(access_key, "InstallLocation")
+        except Exception as err:
+            logging.error(f'Could not dynamically determine League install location : {str(err)}')
+            logging.error(sys.exc_info())
 
     logging.debug(f"League path determined to be: {league_path}")
     return league_path


### PR DESCRIPTION

## Description
This adds support for manual League install directory specification (via config), and associated README updates.

Theoretically this should enable Garena support (if they specify the install folder via config file using syntax in README)

This fixes https://github.com/Kyrluckechuck/TFT-Bot/issues/37