### PR TITLE
Convert All Paths To Expected Format (Sanitize Slashes)

### DIFF
--- a/system_helpers.py
+++ b/system_helpers.py
@@ -2,6 +2,7 @@
 import http.client as httplib
 import logging
 import os
+import pathlib
 import sys
 import winreg
 
@@ -159,5 +160,8 @@ def determine_league_install_location(override_path: str | None=None) -> str:
             logging.error(f'Could not dynamically determine League install location : {str(err)}')
             logging.error(sys.exc_info())
 
+    league_path = str(pathlib.PureWindowsPath(league_path))
+
     logging.debug(f"League path determined to be: {league_path}")
+
     return league_path


### PR DESCRIPTION
![](https://media.giphy.com/media/U3Nx8EtP7h1p0WFKat/giphy.gif)

## Description
Pass all paths into `pathlib` to convert to Windows-safe path (which will result in consistent slash formatting)

Fixes https://github.com/Kyrluckechuck/TFT-Bot/issues/43