### PR TITLE
Update Actions Workflow To Work For Pull Requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: Main CI
 
-on: [push]
+on:
+  workflow_dispatch:
+  push:
 
 jobs:
   build:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,6 +1,8 @@
 name: Pylint
 
-on: [push]
+on:
+  workflow_dispatch:
+  push:
 
 jobs:
   import-sorting:


### PR DESCRIPTION
![](https://media.giphy.com/media/EukOAWKKs0QoW3ps7Z/giphy.gif)

## Description
Right now the two main CI steps only trigger on `push`, but the `push` event does not happen if it's an external pull request.

A followup should be made at some point to actually enable the linting, since right now all it does is confirm the dependencies install correctly.