### PR TITLE
Kill Riot Client When Starting League

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -18,6 +18,7 @@ CONSTANTS = {
         "client": "LeagueClient.exe",
         "client_ux": "LeagueClientUx.exe",
         "game": "League of Legends.exe",
+        "rito_client": "RiotClientServices.exe",
     },
     "tft_logo": {
         "base": "captures/tft_logo.png",
@@ -226,4 +227,11 @@ give_feedback = [
 message_exit_buttons = [
     CONSTANTS["client"]["messages"]["buttons"]["message_exit"]["1"],
     CONSTANTS["client"]["messages"]["buttons"]["message_exit"]["2"],
+]
+
+league_processes = [
+    CONSTANTS["processes"]["client"],
+    CONSTANTS["processes"]["client_ux"],
+    CONSTANTS["processes"]["game"],
+    CONSTANTS["processes"]["rito_client"],
 ]

--- a/tft.py
+++ b/tft.py
@@ -23,6 +23,7 @@ from constants import exit_now_images
 from constants import find_match_images
 from constants import message_exit_buttons
 from constants import wanted_traits
+from constants import league_processes
 import lcu_integration
 from screen_helpers import onscreen
 from screen_helpers import onscreen_multiple_any
@@ -93,23 +94,30 @@ def parse_task_kill_text(result: subprocess.CompletedProcess[str]) -> None:
         logger.debug(result)
 
 
+def kill_process(process_executable: str) -> str:
+    """Kill the process, and parse whether it was successfully killed
+
+    Args:
+        process_executable (str): The process executable to kill
+
+    Returns:
+        str: _description_
+    """
+    return subprocess.run(
+        ["taskkill", "/f", "/im", process_executable],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
 def restart_league_client() -> None:
     """Restarts the league client."""
-    logger.debug("Killing League Client!")
-    result = subprocess.run(
-        ["taskkill", "/f", "/im", CONSTANTS["processes"]["client"]],
-        check=False,
-        capture_output=True,
-        text=True,
-    )
-    parse_task_kill_text(result)
-    result = subprocess.run(
-        ["taskkill", "/f", "/im", CONSTANTS["processes"]["client_ux"]],
-        check=False,
-        capture_output=True,
-        text=True,
-    )
-    parse_task_kill_text(result)
+    logger.debug("Killing League Processes!")
+    for process_to_kill in league_processes:
+        logger.debug(f"Killing {process_to_kill}")
+        result = kill_process(process_to_kill)
+        parse_task_kill_text(result)
     time.sleep(1)
     subprocess.run(CONSTANTS["executables"]["league"]["client"], check=True)
     time.sleep(3)
@@ -813,6 +821,9 @@ def main():
 
     league_directory = LCU_INTEGRATION.get_installation_directory()
     update_league_constants(league_directory)
+
+    logger.info("worked as expected")
+    sys.exit(0)
 
     global PROGRAM_START
     PROGRAM_START = datetime.now()

--- a/tft.py
+++ b/tft.py
@@ -21,9 +21,9 @@ from click_helpers import click_to_middle_multiple
 from constants import CONSTANTS
 from constants import exit_now_images
 from constants import find_match_images
+from constants import league_processes
 from constants import message_exit_buttons
 from constants import wanted_traits
-from constants import league_processes
 import lcu_integration
 from screen_helpers import onscreen
 from screen_helpers import onscreen_multiple_any

--- a/tft.py
+++ b/tft.py
@@ -822,9 +822,6 @@ def main():
     league_directory = LCU_INTEGRATION.get_installation_directory()
     update_league_constants(league_directory)
 
-    logger.info("worked as expected")
-    sys.exit(0)
-
     global PROGRAM_START
     PROGRAM_START = datetime.now()
     tft_bot_loop()


### PR DESCRIPTION
![](https://media.giphy.com/media/yNFjQR6zKOGmk/giphy.gif)

## Description
Kill the ~Rito~ Riot client when starting/restarting the league client.

This will account for a scenario where the RiotClientServices process has decided it lives in the background and interferes with launching League.

Fixes https://github.com/Kyrluckechuck/TFT-Bot/issues/102