### PR TITLE
Update To Python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,7 @@ jobs:
     strategy:
       matrix:
         python-version: [
-          "3.10",
-          # "3.11"
+          "3.11"
         ]
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: [windows-latest]
     strategy:
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.11"]
     steps:
     - uses: actions/checkout@v3
     - name: Set Up Python ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Override any League client detection logic. This should be set to whichever dire
 
 # Installation (for source):
 
-* Install Python 3.10 from [here](https://www.python.org/downloads/), or the Windows Store
+* Install Python 3.11 from [here](https://www.python.org/downloads/), or the Windows Store
 * Navigate to your install directory using `cd` and run `pip install -r requirements.txt` in Command Prompt
 * Navigate to your install directory using `cd` and run `py tft.py` in Command Prompt
 * Follow the instructions in your terminal window! Get into a TFT lobby, have the created window visible on your screen, and press 'OK' to start the bot!

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ PyAutoGUI==0.9.53
 python-imagesearch==1.2.2
 psutil==5.9.4
 argparse==1.4.0
-pywin32==306
+pywin32==306; platform_system == "Windows"
 pyinstaller==5.9.0
 pylint==2.17.1
 keyboard==0.13.5


### PR DESCRIPTION
![](https://media.giphy.com/media/j3WJjjm1OKV73l6E6e/giphy.gif)

## Description
Updates the project to use Python 3.11, and removes the 3.10 linting test since there's no reason to still run that.

## Notes
In the release notes, ensure to mention that while this will likely continue to work on 3.10 installs, all bugs and issues on that version will be considered unsupported.

This also adds the Windows-only marker for `pywin32` so that if you're using WSL on Windows you are still able to do a `pip install` to get the pre-commit package without it fighting you that `pywin32` is not available on Linux.

Addresses #109