### PR TITLE
Add graceful game end logic

### DIFF
--- a/tft.py
+++ b/tft.py
@@ -454,7 +454,15 @@ def check_if_game_complete(wait_for_exit_buttons: bool = False) -> bool:
             parse_task_kill_result(kill_process(CONSTANTS["processes"]["game"], force=False))
             # The second request "confirms" the wish.
             parse_task_kill_result(kill_process(CONSTANTS["processes"]["game"], force=False))
-            time.sleep(5)
+            logger.info("Waiting ~60s for graceful exit")
+            for _ in range(60):
+                if not LCU_INTEGRATION.in_game():
+                    break
+                time.sleep(1)
+            else:
+                logger.error("Game did not exit gracefully, restarting everything to be safe")
+                restart_league_client()
+                return True
             return True
 
         return False

--- a/tft.py
+++ b/tft.py
@@ -799,7 +799,7 @@ def main():
 
     storage_path = "output"
     for process in psutil.process_iter():
-        if process.name() in {"TFT Bot", "TFT Bot.exe"}:
+        if process.name() in {"TFT Bot.exe", "TFT.Bot.exe"}:
             storage_path = system_helpers.expand_environment_variables(CONSTANTS["storage"]["appdata"])
             break
 

--- a/tft.py
+++ b/tft.py
@@ -465,7 +465,6 @@ def check_if_game_complete(wait_for_exit_buttons: bool = False) -> bool:
             else:
                 logger.error("Game did not exit gracefully, restarting everything to be safe")
                 restart_league_client()
-                return True
             return True
 
         return False

--- a/tft.py
+++ b/tft.py
@@ -109,8 +109,11 @@ def kill_process(process_executable: str, force: bool = True) -> subprocess.Comp
     Returns:
         str: _description_
     """
+    task_kill_args = ["taskkill", "/im", process_executable]
+    if force:
+        task_kill_args.insert(1, "/f")
     return subprocess.run(
-        f"taskkill{' /f' if force else ''} /im \"{process_executable}\"",
+        task_kill_args,
         check=False,
         capture_output=True,
         text=True,


### PR DESCRIPTION
# Description
Implements a better way to fall back on regarding ending lost games by asking the program to exit through `taskkill` gracefully.

# Notes
I've been considering making this the standard way of exiting. However, there is a delay between us reaching 0 HP and the game showing Exit buttons to wait for all combats to finish, so I decided not to.

Out-of-scope commit fixing an issue that's not worth a separate PR, fixes #119 

Addresses #118 (Not saying it's fixed before the user confirms it this time.)