### PR TITLE
Add update notifier

### DIFF
--- a/installer.py
+++ b/installer.py
@@ -11,6 +11,8 @@ PyInstaller.__main__.run(
         "captures;captures",
         "--add-data",
         "tft_bot/resources;tft_bot/resources",
+        "--add-data",
+        "VERSION;.",
         "-n",
         "TFT Bot",
         "-i",

--- a/installer.py
+++ b/installer.py
@@ -20,6 +20,7 @@ PyInstaller.__main__.run(
         "--console",
         "--win-private-assemblies",
         "--win-no-prefer-redirects",
+        "--uac-admin",
         "--clean",
         "--runtime-tmpdir",
         constants.CONSTANTS["storage"]["appdata"],


### PR DESCRIPTION
# Description
This PR addresses "Version detection" of #124. It makes more sense to keep the config versioning separate from the project versioning, so we do not update the config for updates that do not edit it.

Implements a version update notifier by sending an API request to this repository's latest release, comparing the tag with the string in the `VERSION` file. The comparison ignores everything in the semantic version after the `patch` segment (position 3).

When a new version is detected, the user will be notified on start-up through a pop-up detailing their and the repository's version. They may download it (the button opens the release page in their default browser) or ignore it.

I decided to implement this first since it seems that we have had quite a few releases recently :)

# Notes
Usually, you would add a checkbox denoting an option to ignore the update until the following remote version change. However, this is not possible with the limited GUI scope we have at the moment. I might be wrong, though, so feel free to point it out if you know if it is possible off the top of your head!

Out-of-scope commit that marks the executable to be run as administrator. This prevents the obligatory "Have you tried running as administrator?" question if someone opens an issue.