### PR TITLE
Create Config/Log Output Directory If Not Existing

### DIFF
--- a/tft_bot/config.py
+++ b/tft_bot/config.py
@@ -28,6 +28,9 @@ def load_config(storage_path: str) -> None:
     config_resource_path = system_helpers.resource_path("tft_bot/resources/config.yaml")
     config_path = f"{storage_path}\\config.yaml"
 
+    # Create output directory if it does not exist
+    os.makedirs(os.path.dirname(config_path), exist_ok=True)
+
     if not os.path.isfile(config_path):
         shutil.copyfile(config_resource_path, config_path)
 


### PR DESCRIPTION
![](https://media.giphy.com/media/l3fZGx5wFR69rNGuc/giphy.gif)

## Description
Creates the config/log output directory if it does not already exist

Fixes https://github.com/Kyrluckechuck/TFT-Bot/issues/127