### PR TITLE
Add configurable timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ You can set the following settings:
 * Forfeiting early
 * Overriding the assumed League Of Legends installation path
 * Traits the bot should look for and how they should be bought
+* Timeouts the bot waits for throughout its various loop logic parts
 
 The settings are explained below but also in more detail in the file itself.
 
@@ -62,7 +63,9 @@ Override any League client detection logic. This should be set to whichever dire
 #### **Wanted Traits**
 Which traits the bot should look for.
 #### **Purchase traits in prioritized order**
-If a trait in the configured trait list should only be bought if the trait that comes before it was bought. 
+If a trait in the configured trait list should only be bought if the trait that comes before it was bought.
+#### **Timeouts**
+Anytime the bot waits for something to happen. The default values should work for most people, but can be adjusted for slower internet speed or hardware.
 
 # Installation (for source):
 

--- a/tft.py
+++ b/tft.py
@@ -35,6 +35,7 @@ from tft_bot.league_api import league_api_integration
 auto.FAILSAFE = False
 GAME_COUNT = 0
 PROGRAM_START: datetime
+LAST_TIMER_PRINTED_AT: datetime = datetime.now()
 PAUSE_LOGIC = False
 PLAY_NEXT_GAME = True
 LCU_INTEGRATION = league_api_integration.LCUIntegration()
@@ -688,7 +689,12 @@ def surrender() -> None:
 
 def print_timer() -> None:
     """Print a log timer to update the time passed and number of games completed (rough estimation)."""
-    delta_seconds = int((datetime.now() - PROGRAM_START).total_seconds())
+    global LAST_TIMER_PRINTED_AT
+    now = datetime.now()
+    if (now - LAST_TIMER_PRINTED_AT).total_seconds() < 300:
+        return
+
+    delta_seconds = int((now - PROGRAM_START).total_seconds())
     global GAME_COUNT
     GAME_COUNT += 1
 
@@ -698,6 +704,8 @@ def print_timer() -> None:
     logger.info(f"Games played: {str(GAME_COUNT)}")
     logger.info(f"Win rate (at most last 20 games): {LCU_INTEGRATION.get_win_rate(GAME_COUNT)}%")
     logger.info("-----------------------------------------")
+
+    LAST_TIMER_PRINTED_AT = datetime.now()
 
 
 def tft_bot_loop() -> None:
@@ -898,5 +906,6 @@ if __name__ == "__main__":
     try:
         sys.exit(main())
     except KeyboardInterrupt:
-        logger.info("Received wish to exit by CTRL+C, exiting immediately.")
+        logger.info("Received wish to exit by CTRL+C, exiting")
+        print_timer()
         sys.exit(0)

--- a/tft.py
+++ b/tft.py
@@ -457,6 +457,10 @@ def check_if_game_complete(wait_for_exit_buttons: bool = False) -> bool:
                 restart_league_client()
             return True
 
+        if LCU_INTEGRATION.session_expired():
+            logger.warning("Our session expired while we were in a game. We have to restart")
+            restart_league_client()
+
         return False
 
     return not check_if_client_error()

--- a/tft.py
+++ b/tft.py
@@ -169,22 +169,6 @@ def toggle_play_next_game() -> None:
         logger.warning("Bot will queue a new game when in lobby!")
 
 
-def wait_for_league_running() -> bool:
-    """Attempt to pause the bot logic evaluation until the league game client is running, or 30 seconds has passed.
-
-    Returns:
-        bool: True if the game is running, False otherwise.
-    """
-    counter = 0
-    while not league_game_already_running():
-        counter = counter + 1
-        time.sleep(0.5)
-        if counter > 60:
-            logger.info("Timed out, moving on!")
-            break
-    return league_game_already_running()
-
-
 def evaluate_next_game_logic() -> None:
     """Don't queue next game, but continue current if already playing.
 
@@ -263,15 +247,17 @@ def loading_match() -> None:
     """Attempt to wait for the match to load, bringing the League game to the forefront/focus.
     After some time, if the game has not been detected as starting, it moves on anyway.
     """
-    logger.info("Waiting for the game window (~30s timeout)")
-    if not GAME_CLIENT_INTEGRATION.wait_for_game_window(lcu_integration=LCU_INTEGRATION):
+    game_window_timeout = config.get_timeout(config.Timeout.GAME_WINDOW, 30)
+    logger.info(f"Waiting for the game window (~{game_window_timeout}s timeout)")
+    if not GAME_CLIENT_INTEGRATION.wait_for_game_window(lcu_integration=LCU_INTEGRATION, timeout=game_window_timeout):
         if LCU_INTEGRATION.in_game():
             logger.warning("We are in a game, but the game window is not opening. Restarting client...")
             restart_league_client()
         return
 
-    logger.info("Match loading, waiting for game to start (~120s timeout)")
-    for _ in range(120):
+    game_start_timeout = config.get_timeout(config.Timeout.GAME_START, 120)
+    logger.info(f"Match loading, waiting for game to start (~{game_start_timeout}s timeout)")
+    for _ in range(game_start_timeout):
         if GAME_CLIENT_INTEGRATION.game_loaded():
             break
         time.sleep(1)
@@ -423,8 +409,9 @@ def check_if_game_complete(wait_for_exit_buttons: bool = False) -> bool:
         bool: True if any scenario in which the game is not active, False otherwise.
     """
     if wait_for_exit_buttons:
-        logger.info("Waiting an additional ~25s for any exit buttons")
-        for _ in range(24):
+        exit_button_timeout = config.get_timeout(config.Timeout.EXIT_BUTTON, 25)
+        logger.info(f"Waiting an additional ~{exit_button_timeout}s for any exit buttons")
+        for _ in range(exit_button_timeout - 1):
             if check_screen_for_exit_button():
                 return True
             time.sleep(1)
@@ -447,8 +434,9 @@ def check_if_game_complete(wait_for_exit_buttons: bool = False) -> bool:
             parse_task_kill_result(kill_process(CONSTANTS["processes"]["game"], force=False))
             # The second request "confirms" the wish.
             parse_task_kill_result(kill_process(CONSTANTS["processes"]["game"], force=False))
-            logger.info("Waiting ~60s for graceful exit")
-            for _ in range(60):
+            graceful_exit_timeout = config.get_timeout(config.Timeout.GRACEFUL_EXIT, 60)
+            logger.info(f"Waiting ~{graceful_exit_timeout}s for graceful exit")
+            for _ in range(graceful_exit_timeout):
                 if not LCU_INTEGRATION.in_game():
                     break
                 time.sleep(1)
@@ -657,7 +645,9 @@ def match_complete() -> None:
 
 def surrender() -> None:
     """Attempt to surrender."""
-    random_seconds = random.randint(60, 90)
+    random_seconds = random.randint(
+        config.get_timeout(config.Timeout.SURRENDER_MIN, 60), config.get_timeout(config.Timeout.SURRENDER_MAX, 90)
+    )
     logger.info(f"Waiting {random_seconds} seconds before surrendering...")
     time.sleep(random_seconds)
     logger.info("Starting surrender")
@@ -756,10 +746,11 @@ def get_newer_version() -> tuple[str, str] | None:
         A tuple of local version and repository version, or None if there is no newer version.
 
     """
-    logger.info("Checking if there is a newer version (10s timeout)")
+    update_notifier_timeout = config.get_timeout(config.Timeout.UPDATE_NOTIFIER, 10)
+    logger.info(f"Checking if there is a newer version ({update_notifier_timeout}s timeout)")
     try:
         repository_version_response = requests.get(
-            "https://api.github.com/repos/Kyrluckechuck/TFT-Bot/releases/latest", timeout=10
+            "https://api.github.com/repos/Kyrluckechuck/TFT-Bot/releases/latest", timeout=update_notifier_timeout
         )
     except requests.exceptions.Timeout:
         logger.debug("Could not connect to GitHub API, continuing as if there is no newer version")

--- a/tft_bot/config.py
+++ b/tft_bot/config.py
@@ -2,6 +2,8 @@
 Module to handle the configuration for the bot.
 """
 import argparse
+from enum import auto
+from enum import StrEnum
 import os.path
 import shutil
 from typing import Any
@@ -12,6 +14,23 @@ from ruamel.yaml import YAML
 from .helpers import system_helpers
 
 _SELF: dict[str, Any] = {}
+
+
+class Timeout(StrEnum):
+    """
+    ENUM class to hold the various names of timeouts we allow to be configured.
+    """
+
+    UPDATE_NOTIFIER = auto()
+    LEAGUE_CLIENT = auto()
+    CLIENT_CONNECT = auto()
+    CLIENT_AVAILABILITY = auto()
+    GAME_WINDOW = auto()
+    GAME_START = auto()
+    EXIT_BUTTON = auto()
+    GRACEFUL_EXIT = auto()
+    SURRENDER_MIN = auto()
+    SURRENDER_MAX = auto()
 
 
 def load_config(storage_path: str) -> None:
@@ -134,3 +153,18 @@ def purchase_traits_in_prioritized_order() -> bool:
 
     """
     return _SELF.get("purchase_traits_in_prioritized_order", True)
+
+
+def get_timeout(timeout: Timeout, default: int) -> int:
+    """
+    Get a timeout value by enum class member.
+
+    Args:
+        timeout: The timeout to get from the config.
+        default: The default to fall back to, if the value is missing in the config.
+
+    Returns:
+        The timeout in seconds.
+
+    """
+    return _SELF.get(timeout, default)

--- a/tft_bot/league_api/league_api_integration.py
+++ b/tft_bot/league_api/league_api_integration.py
@@ -9,6 +9,8 @@ from psutil import process_iter
 import requests
 from requests import HTTPError
 
+from tft_bot import config
+
 # Potentially make this configurable in the future
 # to let the user select their preferred tft mode.
 from tft_bot.helpers import system_helpers
@@ -112,13 +114,14 @@ class LCUIntegration:
             True if we succeeded in connecting, False if not.
 
         """
-        logger.info("Waiting for the League client (~5m timeout)")
+        league_client_timeout = config.get_timeout(config.Timeout.LEAGUE_CLIENT, 300)
+        logger.info(f"Waiting for the League client (~{league_client_timeout}s timeout)")
         lcu_process = get_lcu_process()
 
         timeout = 0
         while not lcu_process:
-            if timeout >= 300:
-                logger.warning("Couldn't find the League client within 5 minutes, exiting")
+            if timeout >= league_client_timeout:
+                logger.warning(f"Couldn't find the League client within {league_client_timeout}s, exiting")
                 return False
             logger.debug("Couldn't find LCUx process yet. Re-searching process list...")
             time.sleep(1)
@@ -131,10 +134,11 @@ class LCUIntegration:
         self._url = f"https://127.0.0.1:{process_arguments['app-port']}"
         self._session.auth = ("riot", process_arguments["remoting-auth-token"])
 
-        logger.info("League client found, trying to connect to it (~60s timeout)")
+        connect_timeout = config.get_timeout(config.Timeout.CLIENT_CONNECT, 60)
+        logger.info(f"League client found, trying to connect to it (~{connect_timeout}s timeout)")
         timeout = 0
         while True:
-            if timeout >= 60:
+            if timeout >= connect_timeout:
                 logger.warning("Couldn't connect to the League client, exiting")
                 return False
 
@@ -151,15 +155,14 @@ class LCUIntegration:
         logger.info("Successfully connected to the League client")
 
         if wait_for_availability:
-            logger.info("Waiting for client availability (~120s timeout)")
-            timeout = 0
-            while timeout < 120:
+            availability_timeout = config.get_timeout(config.Timeout.CLIENT_AVAILABILITY, 120)
+            logger.info(f"Waiting for client availability (~{availability_timeout}s timeout)")
+            for _ in range(availability_timeout):
                 availability_response = self._session.get(url=f"{self._url}/lol-gameflow/v1/availability")
                 if availability_response.status_code == 200 and availability_response.json()["isAvailable"]:
                     logger.info("Client available, queue logic should start")
                     return True
                 time.sleep(1)
-                timeout += 1
             logger.error("Client did not become available. Exiting.")
             return False
 
@@ -398,12 +401,15 @@ class GameClientIntegration:
         )
         self._session.verify = system_helpers.resource_path("tft_bot/resources/riotgames_root_certificate.pem")
 
-    def wait_for_game_window(self, lcu_integration: LCUIntegration, connection_error_counter: int = 0) -> bool:
+    def wait_for_game_window(
+        self, lcu_integration: LCUIntegration, timeout: int, connection_error_counter: int = 0
+    ) -> bool:
         """
         Waits for the API to be responsive, which also means the game window is available.
 
         Args:
             lcu_integration: The object to interact with the LCU.
+            timeout: The approximate time to wait for a successful connection before giving up.
             connection_error_counter: The amount of times we received a connection error, should only be set by itself.
 
         Returns:
@@ -411,9 +417,9 @@ class GameClientIntegration:
 
         """
         try:
-            self._session.get(f"{self._url}", timeout=(30, None))
+            self._session.get(f"{self._url}", timeout=(timeout, None))
         except requests.exceptions.ConnectionError:
-            if connection_error_counter == 30:
+            if connection_error_counter == timeout:
                 return False
 
             time.sleep(1)
@@ -423,7 +429,7 @@ class GameClientIntegration:
                 time.sleep(5)
 
             return self.wait_for_game_window(
-                lcu_integration=lcu_integration, connection_error_counter=connection_error_counter + 1
+                lcu_integration=lcu_integration, timeout=timeout, connection_error_counter=connection_error_counter + 1
             )
         except requests.exceptions.Timeout:
             return False

--- a/tft_bot/league_api/league_api_integration.py
+++ b/tft_bot/league_api/league_api_integration.py
@@ -366,7 +366,7 @@ class LCUIntegration:
 
         try:
             matches_response.raise_for_status()
-        except HTTPError:
+        except (AttributeError, HTTPError):
             return "ERROR"
 
         games = matches_response.json()["games"]

--- a/tft_bot/resources/config.yaml
+++ b/tft_bot/resources/config.yaml
@@ -24,6 +24,31 @@ wanted_traits:
 # to buy all traits.
 purchase_traits_in_prioritized_order: true
 
+# Configure the various timeouts the bot uses throughout it's looping logic.
+# Adjust these to account for differences in internet/hardware speed.
+# All of these are measured in seconds.
+timeouts:
+  # Time we wait to check for any updates.
+  update_notifier: 10
+  # Time we wait to find the league client process to exist.
+  league_client: 300
+  # Time we wait for us to successfully connect to the league client.
+  client_connect: 60
+  # Time we wait for the client to tell us that it's done loadin.
+  client_availability: 120
+  # Time we wait between a match being marked as started and the game showing up.
+  game_window: 30
+  # Time we wait for the load screen to finish.
+  game_start: 120
+  # Time we wait for the exit button after being dead.
+  exit_button: 25
+  # Time we wait for the fall-back method to work if no exit button is found.
+  graceful_exit: 60
+  # Time to wait AT LEAST before surrendering, after we detected that we can.
+  surrender_min: 60
+  # Time to wait AT MOST before surrendering.
+  surrender_max: 90
+
 # Override where League is installed.
 # The only reason you would set this is if all of these conditions apply:
 # 1. You're initially starting the bot while the League Client is closed
@@ -32,4 +57,4 @@ purchase_traits_in_prioritized_order: true
 override_install_location: ''
 
 # Version of the YAML. Changing this manually can potentially break the bot, so don't!
-version: 2
+version: 3


### PR DESCRIPTION
![Miss Minutes GIF](https://media.tenor.com/M7SIXoFqrKYAAAAC/minutes.gif)

# Description
Addresses one of the tasks in #124. Adds a map to the config with pre-defined timeouts. Leverages enum, so it's as little effort as possible on our side to add more timeout options in the future.

# Notes
Fixes an issue where the bot got stuck if the session expires while being in-game.
Fixes an issue where we got an error if the match history returns None.
Now prints the timer if CTRL+C was pressed. Additionally limits the timer from being printed too many times.

I've also tried adding a fitting gif to follow your fancy PRs :D