### PR TITLE
Switch Directory To Avoid Loading Full Paths For Assets

### DIFF
--- a/tft_bot/helpers/system_helpers.py
+++ b/tft_bot/helpers/system_helpers.py
@@ -125,10 +125,10 @@ def resource_path(relative_path: str) -> str:
         base_path = sys._MEIPASS  # pylint: disable=no-member,protected-access
     except Exception:
         base_path = os.path.abspath(".")
+        
+    os.chdir(base_path)
 
-    if relative_path.startswith(base_path):
-        return relative_path
-    return os.path.join(base_path, relative_path)
+    return relative_path
 
 
 def expand_environment_variables(var: str) -> str:

--- a/tft_bot/helpers/system_helpers.py
+++ b/tft_bot/helpers/system_helpers.py
@@ -115,6 +115,11 @@ def disable_quickedit() -> None:
 def resource_path(relative_path: str) -> str:
     """Convert the given relative path to the expanded temp directory path.
 
+    NOTES
+    Change the local application context to ensure assets are asked for relative to the main asset folder.
+    This is related to an issue with https://github.com/Kyrluckechuck/TFT-Bot/issues/129
+    This can likely be done in a cleaner maner but is being left as-is since it's a viable fix.
+
     Args:
         relative_path (str): The relative path to expand.
 

--- a/tft_bot/helpers/system_helpers.py
+++ b/tft_bot/helpers/system_helpers.py
@@ -125,7 +125,7 @@ def resource_path(relative_path: str) -> str:
         base_path = sys._MEIPASS  # pylint: disable=no-member,protected-access
     except Exception:
         base_path = os.path.abspath(".")
-        
+
     os.chdir(base_path)
 
     return relative_path


### PR DESCRIPTION
![](https://media.giphy.com/media/CWbmxaLcHDGahmtqoc/giphy.gif)

## Description
Instead of prepending the current directory to the asset path, change the local application context to ensure it's using the applications directory context. This will help avoid weird ASCII vs Unicode issues specifically relating to the directory/path the application is being executed in (or the temp files are run from).

Fixes #129

## Notes
I haven't tested this too deeply, but I have run the bot from source the last few days without issue.