### PR TITLE
Add economic decisions backed by OCR

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,26 +4,22 @@
 This is an auto TFT bot, with some decent logic built in.
 
 Some features of this bot:
+- Compiles to release executables, so you do not need Python / pip installed in order to use it.
+  - This includes being able to completely customize how the bot works through a [config file](#configuration), so you do not need to install python / pip for this either.
 - Keyboard shortcuts use the [keyboard](https://pypi.org/project/keyboard/) package, which allows it to listen globally (so you don't need to have the console selected in the foreground for this to take effect)
   - Ability to pause/resume the bot using `alt+p`
   - Ability to not re-queue the bot for a new game using `alt+n`
 - Does not surrender games early, by default, allowing it to play out most games, which at the ELO your bot will end up at means there's a decent chance you end up in top 4
   - If you're using this for event pass grinding, it will increase your odds of being top 4 which increases the points earned per minute played (faster pass progression)
 - Draft stage pathing (does not just walk to one point, will walk counter-clockwise to try to ensure it picks up a champ)
-- Basic gold logic to only click based on the gold available
-  - If >= 4, buy xp
-  - If >= 1, attempt 3 champ purchases
-    - After that, if >= 2, re-roll
-- Compiles to release executables so you do not need Python / pip installed in order to use it
-- Can load settings from a config file (if you want to customize how it starts up)
-- Automatically detects your League install location from the Windows registry, allowing non-default installs to still benefit from this script
+- Two gold-based decision-making systems, a default one (requires **no** dependency) and a higher-effort one (requires additional dependency).
+- Automatically detects your League install location from the Windows registry.
+  - This means the bot is able to freely start and restart your league client, should any issues arise, no matter where you installed it.
 
 How stable is this you might ask?
 I recorded this screenshot after a couple days if it running straight, and the battlepass XP matches 😜
 
 ![image](https://user-images.githubusercontent.com/7606153/208268290-8956bfb0-62d4-4d2f-9dd9-0c17c4c1a20e.png)
-
-
 
 # Usage / Settings
 
@@ -31,50 +27,6 @@ I recorded this screenshot after a couple days if it running straight, and the b
 * Adding the (`-v` or `--verbose`) argument will enable more verbose debug logging
   * This toggles whether the verbose logging should log to console / window. Verbose logging will always log to the log file.
 * You can use the config file below to "save" these settings
-
-## Configuration
-If you want to use frequent settings / "set it and forget it", you can do so by editing the `config.yaml` file in the data folder (`%APPDATA%\TFT Bot`).
-If you don't see the file or folder, start the bot once, and it should be created.  
-You can set the following settings:
-
-* Level of information displayed to you
-* Forfeiting early
-* Overriding the assumed League Of Legends installation path
-* Traits the bot should look for and how they should be bought
-* Timeouts the bot waits for throughout its various loop logic parts
-
-The settings are explained below but also in more detail in the file itself.
-
-The priority for configuration is as follows:
-
-1. CLI Arguments - Anything passed directly in the command-line takes the highest priority
-2. Configuration - Anything set in the configuration file
-3. Fallback default - Default values the developers deemed sensible
-
-***Note for developers**: The data folder is `./output` when running the python script directly.*
-
-### *Advanced Setting Info*
-#### **Log level**
-The log level is the all-caps word after the time-stamp, and determines the severity of the message following after it.
-`DEBUG` is mainly for developers, `INFO` is useful information for the user, `WARNING` are non-critical issues, `ERROR` are things that went wrong but shouldn't close the bot and `CRITICAL` is something we can not recover from.
-For most users, we do not recommend setting this to anything above `WARNING`.
-#### **Forfeit Early**
-Forfeit at first opportunity instead of playing it out until eliminated.
-#### **Override Install Location**
-Override any League client detection logic. This should be set to whichever directory contains your `LeagueClient.exe`, `LeagueClientUx.exe`, and `Game\League of Legends.exe` executables, which is especially useful for Garena players as I can not automate this detection (from what I've heard).
-#### **Wanted Traits**
-Which traits the bot should look for.
-#### **Purchase traits in prioritized order**
-If a trait in the configured trait list should only be bought if the trait that comes before it was bought.
-#### **Timeouts**
-Anytime the bot waits for something to happen. The default values should work for most people, but can be adjusted for slower internet speed or hardware.
-
-# Installation (for source):
-
-* Install Python 3.11 from [here](https://www.python.org/downloads/), or the Windows Store
-* Navigate to your install directory using `cd` and run `pip install -r requirements.txt` in Command Prompt
-* Navigate to your install directory using `cd` and run `py tft.py` in Command Prompt
-* Follow the instructions in your terminal window! Get into a TFT lobby, have the created window visible on your screen, and press 'OK' to start the bot!
 
 ## Optional: Install Tesseract-OCR & Enable economic decision-making
 
@@ -87,11 +39,39 @@ After you have downloaded and installed Tesseract-OCR, set `mode` unter `economy
 The bot will at its next start-up attempt to detect where Tesseract is installed.
 If that does not work, please manually override it in the `config.yaml`.
 
+## Configuration
+If you want to use frequent settings / "set it and forget it", you can do so by editing the `config.yaml` file in the data folder (`%APPDATA%\TFT Bot`).
+If you don't see the file or folder, start the bot once, and it should be created.  
+You can set the following settings:
+
+* Level of information displayed to you
+* Forfeiting early
+* Overriding the assumed League Of Legends installation path
+* Traits the bot should look for and how they should be bought
+* Timeouts the bot waits for throughout its various loop logic parts
+
+The settings are explained in more detail in the [file itself](tft_bot/resources/config.yaml).
+
+The priority for configuration is as follows:
+
+1. CLI Arguments - Anything passed directly in the command-line takes the highest priority
+2. Configuration - Anything set in the configuration file
+3. Fallback default - Default values the developers deemed sensible
+
+# Installation (for source):
+
+* Install Python 3.11 from [here](https://www.python.org/downloads/), or the Windows Store
+* Navigate to your install directory using `cd` and run `pip install -r requirements.txt` in Command Prompt
+* Navigate to your install directory using `cd` and run `py tft.py` in Command Prompt
+* Follow the instructions in your terminal window! Get into a TFT lobby, have the created window visible on your screen, and press 'OK' to start the bot!
+
+***Note**: The data folder is `./output` when running the python script directly.*
+
 # Troubleshooting:
 
 Common Issues:
 * The bot is configured to work with in-game resolution 1920x1080, and League client resolution 1280x720. (Also Windows scaling 100%) You can switch this up though, just re-capture the images in the captures folder, but support will become more difficult!
-* Make sure to run League and the bot on your main monitor, as it doesn't support additional monitors!
+* Make sure you have any overlays over the normal League game window disabled.
 
 If running from source:
 * If these steps don't work, try running the file with `python "tft.py"` instead (For Windows Store/MacOS/Linux users especially) Likewise, try `pip3` instead of `pip` for installing requirements.

--- a/README.md
+++ b/README.md
@@ -35,8 +35,10 @@ To change this, we support economic decision-making backed by reading the accura
 However, this **requires** Tesseract-OCR to be installed, which you can download a pre-built Windows installer for [here](https://github.com/UB-Mannheim/tesseract/wiki).
 For this bots purpose, you can deselect everything in the components to install to only install the bare minimum.
 
-After you have downloaded and installed Tesseract-OCR, set `mode` unter `economy` to `ocr_standard` in the `config.yaml`.
-The bot will at its next start-up attempt to detect where Tesseract is installed.
+After you have downloaded and installed Tesseract-OCR, set `mode` under `economy` to `ocr_standard` in the `config.yaml`.
+
+The bot will (at its next start-up) attempt to detect where Tesseract is installed.
+
 If that does not work, please manually override it in the `config.yaml`.
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -76,6 +76,17 @@ Anytime the bot waits for something to happen. The default values should work fo
 * Navigate to your install directory using `cd` and run `py tft.py` in Command Prompt
 * Follow the instructions in your terminal window! Get into a TFT lobby, have the created window visible on your screen, and press 'OK' to start the bot!
 
+## Optional: Install Tesseract-OCR & Enable economic decision-making
+
+By default, or if we could not find tesseract on your system, the bot will use a straight-forward logic of constantly leveling, rolling and buying units.
+To change this, we support economic decision-making backed by reading the accurate value of your gold from your screen.
+However, this **requires** Tesseract-OCR to be installed, which you can download a pre-built Windows installer for [here](https://github.com/UB-Mannheim/tesseract/wiki).
+For this bots purpose, you can deselect everything in the components to install to only install the bare minimum.
+
+After you have downloaded and installed Tesseract-OCR, set `enabled` unter `economic-decisions` to `true` in the `config.yaml`.
+The bot will at its next start-up attempt to detect where Tesseract is installed.
+If that does not work, please manually override it in the `config.yaml`.
+
 # Troubleshooting:
 
 Common Issues:

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ To change this, we support economic decision-making backed by reading the accura
 However, this **requires** Tesseract-OCR to be installed, which you can download a pre-built Windows installer for [here](https://github.com/UB-Mannheim/tesseract/wiki).
 For this bots purpose, you can deselect everything in the components to install to only install the bare minimum.
 
-After you have downloaded and installed Tesseract-OCR, set `enabled` unter `economic-decisions` to `true` in the `config.yaml`.
+After you have downloaded and installed Tesseract-OCR, set `mode` unter `economy` to `ocr_standard` in the `config.yaml`.
 The bot will at its next start-up attempt to detect where Tesseract is installed.
 If that does not work, please manually override it in the `config.yaml`.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ PyAutoGUI==0.9.53
 mss==8.0.3
 numpy==1.24.2
 opencv-python==4.7.0.72
+pytesseract==0.3.10
 psutil==5.9.5
 argparse==1.4.0
 pywin32==306; platform_system == "Windows"

--- a/tft.py
+++ b/tft.py
@@ -228,11 +228,11 @@ def queue() -> None:  # pylint: disable=too-many-branches
             if start_queue_repeating:
                 LCU_INTEGRATION.delete_lobby()
                 start_queue_repeating = False
-                time.sleep(1)
+                time.sleep(3)
                 continue
 
             LCU_INTEGRATION.start_queue()
-            time.sleep(1)
+            time.sleep(3)
             start_queue_repeating = True
             continue
 

--- a/tft.py
+++ b/tft.py
@@ -21,10 +21,10 @@ from tft_bot.constants import CONSTANTS
 from tft_bot.constants import exit_now_images
 from tft_bot.constants import league_processes
 from tft_bot.constants import message_exit_buttons
+from tft_bot.economy.base import EconomyMode
 from tft_bot.helpers import system_helpers
 from tft_bot.helpers.click_helpers import click_to
 from tft_bot.helpers.click_helpers import click_to_image
-from tft_bot.helpers.screen_helpers import BoundingBox
 from tft_bot.helpers.screen_helpers import calculate_window_click_offset
 from tft_bot.helpers.screen_helpers import check_league_game_size
 from tft_bot.helpers.screen_helpers import get_on_screen_in_client
@@ -273,7 +273,7 @@ def start_match() -> None:
     while get_on_screen_in_game(CONSTANTS["game"]["round"]["1-1"]):
         shared_draft_pathing()
     logger.info("Initial draft complete, continuing with game")
-    main_game_loop()
+    main_game_loop(economy_mode=config.get_economy_mode())
 
 
 def shared_draft_pathing() -> None:
@@ -295,23 +295,6 @@ def shared_draft_pathing() -> None:
     click_to(position_x=bottom.position_x, position_y=bottom.position_y, action="right")
     time.sleep(2)
     click_to(position_x=right.position_x, position_y=right.position_y, action="right")
-
-
-def buy(iterations: int) -> None:
-    """Attempt to purchase champs with the designated `wanted_traits`.
-    This will iterate the attempts, but only if the gold is detected to at least be 1.
-
-    Args:
-        iterations (int): The number of attempts to purchase a champ.
-    """
-    for _ in range(iterations):
-        if not check_if_gold_at_least(1):
-            return
-        for trait in config.get_wanted_traits():
-            if click_to_image(image_search_result=get_on_screen_in_game(CONSTANTS["game"]["trait"][trait])):
-                time.sleep(0.5)
-            elif config.purchase_traits_in_prioritized_order():
-                return
 
 
 def click_ok_message() -> None:
@@ -479,49 +462,6 @@ def check_if_post_game() -> bool:
     return attempt_reconnect_to_existing_game()
 
 
-def check_gold(num: int) -> bool:
-    """
-    Checks if there is N gold in the region of the gold display.
-
-    Args:
-        num: The amount of gold we're checking for, there should be a file for it in captures/gold .
-
-    Returns:
-        True if we found the amount of gold. False if not.
-
-    """
-    try:
-        if get_on_screen_in_game(CONSTANTS["game"]["gold"][f"{num}"], 0.9, BoundingBox(780, 850, 970, 920)):
-            logger.debug(f"Found {num} gold")
-            return True
-    except Exception as exc:
-        logger.opt(exception=exc).debug(f"Exception finding {num} gold, we possibly don't have the value as a file")
-        # We don't have this gold as a file
-        return True
-    return False
-
-
-def check_if_gold_at_least(num: int) -> bool:
-    """Check if the gold on screen is at least the provided amount
-
-    Args:
-        num (int): The value to check if the gold is at least.
-
-    Returns:
-        bool: True if the value is >= `num`, False otherwise.
-    """
-    logger.debug(f"Looking for at least {num} gold")
-    if check_gold(num):
-        return True
-
-    for i in range(num + 1):
-        if check_gold(i):
-            return i >= num
-
-    logger.debug("No gold value found, assuming we have more")
-    return True
-
-
 def determine_minimum_round() -> int:
     """
     Determines minimum round we are at.
@@ -557,8 +497,12 @@ def determine_minimum_round() -> int:
     return 0
 
 
-def main_game_loop() -> None:  # pylint: disable=too-many-branches
-    """The main in-game loop.
+def main_game_loop(economy_mode: EconomyMode) -> None:
+    """
+    The main in-game loop.
+
+    Args:
+        economy_mode: The economy mode the bot should use
 
     Skips 5-second increments if a pause logic request is made,
     repeating until toggled or an event triggers an early exit.
@@ -589,25 +533,12 @@ def main_game_loop() -> None:  # pylint: disable=too-many-branches
             time.sleep(0.5)
             continue
 
-        if minimum_round <= 2:
-            buy(3)
-            continue
+        economy_mode.loop_decision(minimum_round=minimum_round)
 
-        if config.forfeit_early() and minimum_round >= 3:
+        if minimum_round >= 3 and config.forfeit_early():
             logger.info("Attempting to surrender early")
             surrender()
             break
-
-        # If round > 2, buy champs, level and re-roll
-        buy(3)
-        if check_if_gold_at_least(4):
-            click_to_image(image_search_result=get_on_screen_in_game(CONSTANTS["game"]["gamelogic"]["xp_buy"]))
-            time.sleep(0.5)
-
-        if check_if_gold_at_least(5):
-            click_to_image(image_search_result=get_on_screen_in_game(CONSTANTS["game"]["gamelogic"]["reroll"]))
-            time.sleep(0.5)
-            continue
 
         time.sleep(0.5)
 

--- a/tft.py
+++ b/tft.py
@@ -273,7 +273,7 @@ def start_match() -> None:
     while get_on_screen_in_game(CONSTANTS["game"]["round"]["1-1"]):
         shared_draft_pathing()
     logger.info("Initial draft complete, continuing with game")
-    main_game_loop(economy_mode=config.get_economy_mode())
+    main_game_loop(economy_mode=config.get_economy_mode(system_helpers=system_helpers))
 
 
 def shared_draft_pathing() -> None:
@@ -744,7 +744,7 @@ def main():
             storage_path = system_helpers.expand_environment_variables(CONSTANTS["storage"]["appdata"])
             break
 
-    config.load_config(storage_path=storage_path)
+    config.load_config(system_helpers=system_helpers, storage_path=storage_path)
 
     log_level = config.get_log_level().upper()
     if log_level == "DEBUG":

--- a/tft_bot/config.py
+++ b/tft_bot/config.py
@@ -173,6 +173,17 @@ def get_timeout(timeout: Timeout, default: int) -> int:
     return _SELF.get(timeout, default)
 
 
+def get_tesseract_override_install_location() -> str | None:
+    """
+    Get the value of the override_tesseract_location setting in the config.
+
+    Returns:
+        An optional string containing the user-defined install location.
+
+    """
+    return _SELF["economy"].get("override_tesseract_location") or None
+
+
 def get_economy_mode(system_helpers) -> EconomyMode:
     """
     Get the economy mode the bot should run on.

--- a/tft_bot/config.py
+++ b/tft_bot/config.py
@@ -13,7 +13,7 @@ from ruamel.yaml import YAML
 
 from .economy.base import EconomyMode
 from .economy.default import DefaultEconomyMode
-from .helpers import system_helpers
+from .economy.ocr_standard import OCRStandardEconomyMode
 
 _SELF: dict[str, Any] = {}
 
@@ -35,12 +35,13 @@ class Timeout(StrEnum):
     SURRENDER_MAX = auto()
 
 
-def load_config(storage_path: str) -> None:
+def load_config(system_helpers, storage_path: str) -> None:
     """
     Writes the configuration from resource (provided in repository) to storage path, loads the configuration from
     storage path to memory and updates the configuration if necessary.
 
     Args:
+        system_helpers: Dependency injected system_helpers module.
         storage_path: The base storage path where all of our files should go.
 
     """
@@ -172,16 +173,31 @@ def get_timeout(timeout: Timeout, default: int) -> int:
     return _SELF.get(timeout, default)
 
 
-def get_economy_mode() -> EconomyMode:
+def get_economy_mode(system_helpers) -> EconomyMode:
     """
     Get the economy mode the bot should run on.
+
+    Args:
+        system_helpers: Dependency injected system_helpers module.
 
     Returns:
         A new instance of the economy mode.
 
     """
+    wanted_traits = get_wanted_traits()
+    prioritized_order = purchase_traits_in_prioritized_order()
+
     match _SELF["economy"].get("mode", "default"):
         case "default":
-            return DefaultEconomyMode(
-                wanted_traits=get_wanted_traits(), prioritized_order=purchase_traits_in_prioritized_order()
+            return DefaultEconomyMode(wanted_traits=wanted_traits, prioritized_order=prioritized_order)
+        case "ocr_standard":
+            tesseract_location = system_helpers.determine_tesseract_ocr_install_location() + "\\tesseract.exe"
+            if not os.path.isfile(tesseract_location):
+                logger.warning(
+                    f'Tesseract location "{tesseract_location}" does not exist. Falling back to default economy mode'
+                )
+                return DefaultEconomyMode(wanted_traits=wanted_traits, prioritized_order=prioritized_order)
+
+            return OCRStandardEconomyMode(
+                wanted_traits=wanted_traits, prioritized_order=prioritized_order, tesseract_location=tesseract_location
             )

--- a/tft_bot/config.py
+++ b/tft_bot/config.py
@@ -11,6 +11,8 @@ from typing import Any
 from loguru import logger
 from ruamel.yaml import YAML
 
+from .economy.base import EconomyMode
+from .economy.default import DefaultEconomyMode
 from .helpers import system_helpers
 
 _SELF: dict[str, Any] = {}
@@ -168,3 +170,18 @@ def get_timeout(timeout: Timeout, default: int) -> int:
 
     """
     return _SELF.get(timeout, default)
+
+
+def get_economy_mode() -> EconomyMode:
+    """
+    Get the economy mode the bot should run on.
+
+    Returns:
+        A new instance of the economy mode.
+
+    """
+    match _SELF["economy"].get("mode", "default"):
+        case "default":
+            return DefaultEconomyMode(
+                wanted_traits=get_wanted_traits(), prioritized_order=purchase_traits_in_prioritized_order()
+            )

--- a/tft_bot/economy/base.py
+++ b/tft_bot/economy/base.py
@@ -1,0 +1,59 @@
+"""
+Module holding the base economy mode blueprint class.
+"""
+import time
+
+from tft_bot.constants import CONSTANTS
+from tft_bot.helpers.click_helpers import click_to_image
+from tft_bot.helpers.screen_helpers import get_on_screen_in_game
+
+
+class EconomyMode:
+    """
+    Blueprint class to implement custom economy modes on.
+    """
+
+    def __init__(self, wanted_traits: list[str], prioritized_order: bool):
+        """
+        Init method to dependency-inject the purchase logic.
+        Args:
+            wanted_traits: A list of wanted traits.
+            prioritized_order: Whether to only buy a trait if the trait before it was bought.
+        """
+        self.wanted_traits = wanted_traits
+        self.prioritized_order = prioritized_order
+
+    def loop_decision(self, minimum_round: int) -> None:
+        """
+        Method to be called by the main game loop for the mode to make a decision.
+
+        Args:
+            minimum_round: The n-th round (N-*) we are at.
+        """
+        raise NotImplementedError
+
+    def purchase_units(self, amount: int) -> None:
+        """
+        Attempts to purchase a given amount of units from the pool of configured traits.
+
+        Args:
+            amount: The amount of units to purchase.
+        """
+        for _ in range(amount):
+            for trait in self.wanted_traits:
+                if click_to_image(image_search_result=get_on_screen_in_game(CONSTANTS["game"]["trait"][trait])):
+                    time.sleep(0.5)
+                elif self.prioritized_order:
+                    return
+
+    def roll(self) -> None:
+        """
+        Utility method to roll (refresh) the shop once.
+        """
+        click_to_image(image_search_result=get_on_screen_in_game(CONSTANTS["game"]["gamelogic"]["reroll"]))
+
+    def purchase_xp(self) -> None:
+        """
+        Utility method to purchase xp once.
+        """
+        click_to_image(image_search_result=get_on_screen_in_game(CONSTANTS["game"]["gamelogic"]["xp_buy"]))

--- a/tft_bot/economy/default.py
+++ b/tft_bot/economy/default.py
@@ -1,0 +1,76 @@
+"""
+Module holding the default economy mode.
+"""
+import time
+
+from loguru import logger
+
+from ..constants import CONSTANTS
+from ..helpers.screen_helpers import BoundingBox
+from ..helpers.screen_helpers import get_on_screen_in_game
+from .base import EconomyMode
+
+
+class DefaultEconomyMode(EconomyMode):
+    """
+    Default economy mode implementation.
+    """
+
+    def loop_decision(self, minimum_round: int):
+        if gold_at_least(3):
+            self.purchase_units(amount=3)
+            time.sleep(0.5)
+
+        if minimum_round < 3:
+            return
+
+        if gold_at_least(4):
+            self.purchase_xp()
+            time.sleep(0.5)
+
+        if gold_at_least(5):
+            self.roll()
+            time.sleep(0.5)
+
+
+def get_gold(num: int) -> bool:
+    """
+    Checks if there is N gold in the region of the gold display.
+
+    Args:
+        num: The amount of gold we're checking for, there should be a file for it in captures/gold .
+
+    Returns:
+        True if we found the amount of gold. False if not.
+    """
+    try:
+        if get_on_screen_in_game(CONSTANTS["game"]["gold"][f"{num}"], 0.9, BoundingBox(780, 850, 970, 920)):
+            logger.debug(f"Found {num} gold")
+            return True
+    except Exception as exc:
+        logger.opt(exception=exc).debug(f"Exception finding {num} gold, we possibly don't have the value as a file")
+        # We don't have this gold as a file
+        return True
+    return False
+
+
+def gold_at_least(num: int) -> bool:
+    """
+    Check if the gold on screen is at least the provided amount
+
+    Args:
+        num (int): The value to check if the gold is at least.
+
+    Returns:
+        bool: True if the value is >= `num`, False otherwise.
+    """
+    logger.debug(f"Looking for at least {num} gold")
+    if get_gold(num):
+        return True
+
+    for i in range(num + 1):
+        if get_gold(i):
+            return i >= num
+
+    logger.debug("No gold value found, assuming we have more")
+    return True

--- a/tft_bot/economy/default.py
+++ b/tft_bot/economy/default.py
@@ -3,11 +3,7 @@ Module holding the default economy mode.
 """
 import time
 
-from loguru import logger
-
-from ..constants import CONSTANTS
-from ..helpers.screen_helpers import BoundingBox
-from ..helpers.screen_helpers import get_on_screen_in_game
+from ..helpers import screen_helpers
 from .base import EconomyMode
 
 
@@ -17,60 +13,17 @@ class DefaultEconomyMode(EconomyMode):
     """
 
     def loop_decision(self, minimum_round: int):
-        if gold_at_least(3):
+        if screen_helpers.gold_at_least(3):
             self.purchase_units(amount=3)
             time.sleep(0.5)
 
         if minimum_round < 3:
             return
 
-        if gold_at_least(4):
+        if screen_helpers.gold_at_least(4):
             self.purchase_xp()
             time.sleep(0.5)
 
-        if gold_at_least(5):
+        if screen_helpers.gold_at_least(5):
             self.roll()
             time.sleep(0.5)
-
-
-def get_gold(num: int) -> bool:
-    """
-    Checks if there is N gold in the region of the gold display.
-
-    Args:
-        num: The amount of gold we're checking for, there should be a file for it in captures/gold .
-
-    Returns:
-        True if we found the amount of gold. False if not.
-    """
-    try:
-        if get_on_screen_in_game(CONSTANTS["game"]["gold"][f"{num}"], 0.9, BoundingBox(780, 850, 970, 920)):
-            logger.debug(f"Found {num} gold")
-            return True
-    except Exception as exc:
-        logger.opt(exception=exc).debug(f"Exception finding {num} gold, we possibly don't have the value as a file")
-        # We don't have this gold as a file
-        return True
-    return False
-
-
-def gold_at_least(num: int) -> bool:
-    """
-    Check if the gold on screen is at least the provided amount
-
-    Args:
-        num (int): The value to check if the gold is at least.
-
-    Returns:
-        bool: True if the value is >= `num`, False otherwise.
-    """
-    logger.debug(f"Looking for at least {num} gold")
-    if get_gold(num):
-        return True
-
-    for i in range(num + 1):
-        if get_gold(i):
-            return i >= num
-
-    logger.debug("No gold value found, assuming we have more")
-    return True

--- a/tft_bot/economy/ocr_standard.py
+++ b/tft_bot/economy/ocr_standard.py
@@ -1,11 +1,10 @@
 """
 Module holding the OCR standard economy mode.
 """
-import cv2
-import mss
-import numpy
+from loguru import logger
 from pytesseract import pytesseract
 
+from ..helpers import screen_helpers
 from .base import EconomyMode
 
 
@@ -21,29 +20,11 @@ class OCRStandardEconomyMode(EconomyMode):
     def loop_decision(self, minimum_round: int):
         self.purchase_units(amount=3)
 
-        gold = get_gold()
+        gold = screen_helpers.get_gold()
+        logger.debug(f"OCR recognized {gold} gold")
         if gold >= 54:
             self.purchase_xp()
             gold -= 4
 
         if gold >= 55:
             self.roll()
-
-
-_TESSERACT_CONFIG = '--oem 3 --psm 7 -c tessedit_char_whitelist=0123456789 -c page_separator=""'
-
-
-def get_gold() -> int:
-    """
-    Get the gold by taking a screenshot of the region where it is and running OCR over it.
-
-    Returns:
-        The amount of gold the player currently has.
-
-    """
-    with mss.mss() as screenshot_taker:
-        screenshot = screenshot_taker.grab((867, 881, 924, 909))
-
-    pixels = numpy.array(screenshot)
-    gray_scaled_pixels = cv2.cvtColor(pixels, cv2.COLOR_BGR2GRAY)
-    return int(pytesseract.image_to_string(~gray_scaled_pixels, config=_TESSERACT_CONFIG) or 0)

--- a/tft_bot/economy/ocr_standard.py
+++ b/tft_bot/economy/ocr_standard.py
@@ -20,7 +20,7 @@ class OCRStandardEconomyMode(EconomyMode):
     def loop_decision(self, minimum_round: int):
         self.purchase_units(amount=3)
 
-        gold = screen_helpers.get_gold()
+        gold = screen_helpers.get_gold_with_ocr()
         logger.debug(f"OCR recognized {gold} gold")
         if gold >= 54:
             self.purchase_xp()

--- a/tft_bot/economy/ocr_standard.py
+++ b/tft_bot/economy/ocr_standard.py
@@ -1,0 +1,49 @@
+"""
+Module holding the OCR standard economy mode.
+"""
+import cv2
+import mss
+import numpy
+from pytesseract import pytesseract
+
+from .base import EconomyMode
+
+
+class OCRStandardEconomyMode(EconomyMode):
+    """
+    OCR standard economy mode implementation.
+    """
+
+    def __init__(self, wanted_traits: list[str], prioritized_order: bool, tesseract_location: str):
+        super().__init__(wanted_traits, prioritized_order)
+        pytesseract.tesseract_cmd = tesseract_location
+
+    def loop_decision(self, minimum_round: int):
+        self.purchase_units(amount=3)
+
+        gold = get_gold()
+        if gold >= 54:
+            self.purchase_xp()
+            gold -= 4
+
+        if gold >= 55:
+            self.roll()
+
+
+_TESSERACT_CONFIG = '--oem 3 --psm 7 -c tessedit_char_whitelist=0123456789 -c page_separator=""'
+
+
+def get_gold() -> int:
+    """
+    Get the gold by taking a screenshot of the region where it is and running OCR over it.
+
+    Returns:
+        The amount of gold the player currently has.
+
+    """
+    with mss.mss() as screenshot_taker:
+        screenshot = screenshot_taker.grab((867, 881, 924, 909))
+
+    pixels = numpy.array(screenshot)
+    gray_scaled_pixels = cv2.cvtColor(pixels, cv2.COLOR_BGR2GRAY)
+    return int(pytesseract.image_to_string(~gray_scaled_pixels, config=_TESSERACT_CONFIG) or 0)

--- a/tft_bot/helpers/system_helpers.py
+++ b/tft_bot/helpers/system_helpers.py
@@ -213,14 +213,19 @@ def determine_tesseract_ocr_install_location() -> str:
         If successful, the determined install location. If unsuccessful, the default install location.
     """
     tesseract_ocr_path = r"C:\Program Files\Tesseract-OCR"
+    override_path = config.get_tesseract_override_install_location()
 
-    registry_entry = read_registry(
-        hkey_type=winreg.HKEY_LOCAL_MACHINE, path=r"SOFTWARE\Tesseract-OCR", value="InstallDir"
-    )
-    if registry_entry:
-        tesseract_ocr_path = registry_entry
+    if override_path is not None:
+        logger.warning(f"Override path supplied, using '{override_path}' as Tesseract-OCR install directory.")
+        tesseract_ocr_path = override_path
+    else:
+        registry_entry = read_registry(
+            hkey_type=winreg.HKEY_LOCAL_MACHINE, path=r"SOFTWARE\Tesseract-OCR", value="InstallDir"
+        )
+        if registry_entry:
+            tesseract_ocr_path = registry_entry
 
-    tesseract_ocr_path = str(pathlib.PureWindowsPath(tesseract_ocr_path))
+        tesseract_ocr_path = str(pathlib.PureWindowsPath(tesseract_ocr_path))
 
     logger.debug(f"Tesseract-OCR location determined to be: {tesseract_ocr_path}")
 

--- a/tft_bot/helpers/system_helpers.py
+++ b/tft_bot/helpers/system_helpers.py
@@ -148,6 +148,34 @@ def expand_environment_variables(var: str) -> str:
     return os.path.expandvars(var)
 
 
+def read_registry(hkey_type: int, path: str, value: str) -> str | None:
+    """
+    Read the registry at a specific hkey type and path.
+
+    Args:
+        hkey_type: The HKEY to read at, see winreg.HKEY_*
+        path: The path to read at.
+        value: The specific value to read from the path
+
+    Returns:
+        The value as a str if found, otherwise None.
+    """
+    try:
+        access_registry = winreg.ConnectRegistry(None, hkey_type)
+        access_key = winreg.OpenKey(
+            access_registry,
+            path,
+            0,
+            winreg.KEY_READ,
+        )
+        [path, _] = winreg.QueryValueEx(access_key, value)
+    except Exception as exc:
+        logger.opt(exception=exc).error(f"Could not read registry at {path}\\{value}.")
+        return None
+
+    return path
+
+
 def determine_league_install_location() -> str:
     """Determine the location League was installed.
 
@@ -162,21 +190,38 @@ def determine_league_install_location() -> str:
         logger.warning(f"Override path supplied, using '{override_path}' as League install directory.")
         league_path = override_path
     else:
-        try:
-            access_registry = winreg.ConnectRegistry(None, winreg.HKEY_CURRENT_USER)
-            access_key = winreg.OpenKey(
-                access_registry,
-                r"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Riot Game league_of_legends.live",
-                0,
-                winreg.KEY_READ,
-            )
-            [league_path, _] = winreg.QueryValueEx(access_key, "InstallLocation")
-        except Exception as err:
-            logger.error(f"Could not dynamically determine League install location : {str(err)}")
-            logger.error(sys.exc_info())
+        registry_entry = read_registry(
+            hkey_type=winreg.HKEY_CURRENT_USER,
+            path=r"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Riot Game league_of_legends.live",
+            value="InstallLocation",
+        )
+        if registry_entry:
+            league_path = registry_entry
 
     league_path = str(pathlib.PureWindowsPath(league_path))
 
     logger.debug(f"League path determined to be: {league_path}")
 
     return league_path
+
+
+def determine_tesseract_ocr_install_location() -> str:
+    """
+    Determine the location Tesseract-OCR was installed at.
+
+    Returns:
+        If successful, the determined install location. If unsuccessful, the default install location.
+    """
+    tesseract_ocr_path = r"C:\Program Files\Tesseract-OCR"
+
+    registry_entry = read_registry(
+        hkey_type=winreg.HKEY_LOCAL_MACHINE, path=r"SOFTWARE\Tesseract-OCR", value="InstallDir"
+    )
+    if registry_entry:
+        tesseract_ocr_path = registry_entry
+
+    tesseract_ocr_path = str(pathlib.PureWindowsPath(tesseract_ocr_path))
+
+    logger.debug(f"Tesseract-OCR location determined to be: {tesseract_ocr_path}")
+
+    return tesseract_ocr_path

--- a/tft_bot/resources/config.yaml
+++ b/tft_bot/resources/config.yaml
@@ -32,6 +32,8 @@ economy:
   # "default" constantly spends all gold, cycling equally between purchasing, leveling, and rolling.
   # "ocr_standard" tries to keep your gold at around 50, otherwise behaves like default.
   mode: "default"
+  # Override the automatic detection of tesseract. Should not be needed, but is supported.
+  override_tesseract_location: ""
 
 # Configure the various timeouts the bot uses throughout it's looping logic.
 # Adjust these to account for differences in internet/hardware speed.

--- a/tft_bot/resources/config.yaml
+++ b/tft_bot/resources/config.yaml
@@ -26,6 +26,12 @@ wanted_traits:
 # to buy all traits.
 purchase_traits_in_prioritized_order: true
 
+# Settings for the bots decisions made for purchasing units, leveling and rolling.
+economy:
+  # The mode itself to be used.
+  # "default" constantly spends all gold.
+  mode: "default"
+
 # Configure the various timeouts the bot uses throughout it's looping logic.
 # Adjust these to account for differences in internet/hardware speed.
 # All of these are measured in seconds.
@@ -59,4 +65,4 @@ timeouts:
 override_install_location: ''
 
 # Version of the YAML. Changing this manually can potentially break the bot, so don't!
-version: 4
+version: 5

--- a/tft_bot/resources/config.yaml
+++ b/tft_bot/resources/config.yaml
@@ -28,8 +28,9 @@ purchase_traits_in_prioritized_order: true
 
 # Settings for the bots decisions made for purchasing units, leveling and rolling.
 economy:
-  # The mode itself to be used.
-  # "default" constantly spends all gold.
+  # The mode itself to be used. ocr_* modes require Tesseract-OCR to be installed.
+  # "default" constantly spends all gold, cycling equally between purchasing, leveling, and rolling.
+  # "ocr_standard" tries to keep your gold at around 50, otherwise behaves like default.
   mode: "default"
 
 # Configure the various timeouts the bot uses throughout it's looping logic.


### PR DESCRIPTION
![Money](https://media.tenor.com/CWTSm8gczRYAAAAC/scrooge-mcduck-money.gif)

# Description

Refactors part of the main game loop into a new economy module called `default`, which will remain the default.

Adds a new economy module called `ocr_standard`, which uses OCR to detect how much gold we have and makes a decision based on it. It behaves almost exactly as default: it equally buys units, levels, and rolls the shop. The key difference is that it saves and stays around 50 gold.

I concluded that it is not good to ship pre-built binaries/wheels for ML models and documented in the README how to enable the new option, emphasizing it as an optional nice-to-have.

In case you're wondering about the dependency injection, pylint started detecting circular imports that weren't an issue and have been there before. The DI approach I took should be acceptable to fix it, I am open to feedback as always, though :)

Closes #124 

# Notes
While at it, I cleaned up the README a little so that we could close #28.
I also increased some sleeps in lobby creation, as I noticed the update today made the client slightly less responsive. Not sure how they manage to keep making it worse, but it's not a big deal lol.