### PR TITLE
Increase Client Error Handling Robustness

### DIFF
--- a/tft.py
+++ b/tft.py
@@ -121,6 +121,11 @@ def restart_league_client() -> None:
         result = kill_process(process_to_kill)
         parse_task_kill_result(result)
     time.sleep(1)
+
+    if not system_helpers.internet():
+        wait_for_internet()
+        time.sleep(1)
+
     subprocess.run(CONSTANTS["executables"]["league"]["client"], check=True)
     time.sleep(3)
     if not LCU_INTEGRATION.connect_to_lcu(wait_for_availability=True):
@@ -312,7 +317,7 @@ def click_exit_message() -> None:
 
 def wait_for_internet() -> None:
     """Delay indefinitely until an internet is detected."""
-    while not system_helpers.have_internet():
+    while not system_helpers.internet():
         logger.warning("Internet is not up, will retry in 60 seconds")
         time.sleep(60)
 
@@ -329,10 +334,10 @@ def check_if_client_error() -> bool:  # pylint: disable=too-many-return-statemen
         return acknowledge_error_and_restart_league(delay=300)
     if get_on_screen_in_client(CONSTANTS["client"]["messages"]["failed_to_reconnect"]):
         logger.info("Failed to reconnect!")
-        return acknowledge_error_and_restart_league(internet_pause=True)
+        return acknowledge_error_and_restart_league()
     if get_on_screen_in_client(CONSTANTS["client"]["messages"]["login_servers_down"]):
         logger.info("Login servers down!")
-        return acknowledge_error_and_restart_league(internet_pause=True)
+        return acknowledge_error_and_restart_league()
     if get_on_screen_in_client(CONSTANTS["client"]["messages"]["session_expired"]):
         logger.info("Session expired!")
         return acknowledge_error_and_restart_league()
@@ -345,13 +350,11 @@ def check_if_client_error() -> bool:  # pylint: disable=too-many-return-statemen
     return False
 
 
-def acknowledge_error_and_restart_league(delay: int = 5, internet_pause: bool = False) -> bool:
+def acknowledge_error_and_restart_league(delay: int = 5) -> bool:
     """Acknowledge error message with ok or error button and restart league client"""
     click_exit_message()
     click_ok_message()
     time.sleep(delay)
-    if internet_pause:
-        wait_for_internet()
     restart_league_client()
     return True
 

--- a/tft.py
+++ b/tft.py
@@ -129,7 +129,7 @@ def restart_league_client() -> None:
     subprocess.run(CONSTANTS["executables"]["league"]["client"], check=True)
     time.sleep(3)
     if not LCU_INTEGRATION.connect_to_lcu(wait_for_availability=True):
-        sys.exit(1)
+        restart_league_client()
 
 
 def restart_league_if_not_running() -> bool:
@@ -837,7 +837,7 @@ def main():
         update_league_constants(league_directory)
         restart_league_client()
     elif not LCU_INTEGRATION.connect_to_lcu():
-        sys.exit(1)
+        restart_league_client()
 
     league_directory = LCU_INTEGRATION.get_installation_directory()
     update_league_constants(league_directory)

--- a/tft_bot/helpers/system_helpers.py
+++ b/tft_bot/helpers/system_helpers.py
@@ -74,12 +74,12 @@ def find_in_processes(executable_path: str) -> bool:
     return False
 
 
-def internet(host="8.8.8.8", port=53) -> bool:
+def internet(host="1.1.1.1", port=53) -> bool:
     """
     Checks if there is an active internet connection to the given IP address.
 
     Args:
-        host: The host to connect to. Defaults to "8.8.8.8".
+        host: The host to connect to. Defaults to "1.1.1.1".
         port: The port to connect on. Defaults to 53 (TCP/UDP port for DNS service)
 
     Returns:

--- a/tft_bot/helpers/system_helpers.py
+++ b/tft_bot/helpers/system_helpers.py
@@ -1,7 +1,7 @@
 """A collection of system-level helpers"""
-import http.client as httplib
 import os
 import pathlib
+import socket
 import sys
 import winreg
 
@@ -74,25 +74,23 @@ def find_in_processes(executable_path: str) -> bool:
     return False
 
 
-def have_internet(ip_to_ping="1.1.1.1") -> bool:
-    """Checks if there is an active internet connection to the given IP address, checking if a HEAD request succeeds.
+def internet(host="8.8.8.8", port=53) -> bool:
+    """
+    Checks if there is an active internet connection to the given IP address.
 
     Args:
-        ip_to_ping (str, optional): The IP address to check. Defaults to "1.1.1.1".
+        host: The host to connect to. Defaults to "8.8.8.8".
+        port: The port to connect on. Defaults to 53 (TCP/UDP port for DNS service)
 
     Returns:
-        bool: True if a HEAD request succeeds to the specified IP address, False otherwise.
+        bool: True if the connection succeeds to the specified IP address, False otherwise.
     """
-    conn = httplib.HTTPSConnection(ip_to_ping, timeout=5)
     try:
-        conn.request("HEAD", "/")
-        logger.debug(f"Success pinging {ip_to_ping}")
+        socket.setdefaulttimeout(5)
+        socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect((host, port))
         return True
-    except Exception:
-        logger.debug(f"Can not ping {ip_to_ping}")
+    except socket.error:
         return False
-    finally:
-        conn.close()
 
 
 # Via https://gist.github.com/sthonnard/31106e47eab8d6f3329ef530717e8079


### PR DESCRIPTION
![Fixing everything](https://media.tenor.com/B7TP3JU7qcAAAAAC/fixed.gif)

# Description
Now always waits for an internet connection before starting the league client. The reason is that the Rito Client also checks for internet, and we did not have a check yet.

It also replaces some of the sys.exit calls with restart_league_client.

Fixes #147, I hope?

# Notes
I'd love to get `check_if_client_error` integrated with LCU (which should effectively take care of any error the client could throw at us), but I rarely run into client errors while physically present. I checked the LCU explorer but couldn't find anything at first glance (even though I did find that we can create arbitrary boxes and notification pop-ups ourselves, lol), so if you run into a box yourself, I'd love for you to see if you can find something with the explorer :)