### PR TITLE
Estimate Unit Positions

### DIFF
--- a/installer.py
+++ b/installer.py
@@ -20,7 +20,6 @@ PyInstaller.__main__.run(
         "--console",
         "--win-private-assemblies",
         "--win-no-prefer-redirects",
-        "--uac-admin",
         "--clean",
         "--runtime-tmpdir",
         constants.CONSTANTS["storage"]["appdata"],

--- a/tft.py
+++ b/tft.py
@@ -28,6 +28,7 @@ from tft_bot.helpers.click_helpers import click_to
 from tft_bot.helpers.click_helpers import click_to_image
 from tft_bot.helpers.screen_helpers import calculate_window_click_offset
 from tft_bot.helpers.screen_helpers import check_league_game_size
+from tft_bot.helpers.screen_helpers import get_board_positions
 from tft_bot.helpers.screen_helpers import get_on_screen_in_client
 from tft_bot.helpers.screen_helpers import get_on_screen_in_game
 from tft_bot.league_api import league_api_integration
@@ -534,7 +535,9 @@ def main_game_loop(economy_mode: EconomyMode) -> None:
                 window_title=CONSTANTS["window_titles"]["game"], position_x=960, position_y=540
             )
             click_to(position_x=augment_offset.position_x, position_y=augment_offset.position_y)
-            time.sleep(0.5)
+            time.sleep(3)
+
+            logger.debug(f"Board positions: {get_board_positions()}")
             continue
 
         economy_mode.loop_decision(minimum_round=minimum_round)

--- a/tft.py
+++ b/tft.py
@@ -566,6 +566,7 @@ def end_match() -> None:
         break
 
     bring_league_client_to_forefront()
+    time.sleep(10)
     check_if_client_error()
 
 


### PR DESCRIPTION
![Maths](https://media.tenor.com/D6qv7_KVt7cAAAAC/rocket-science-complicated.gif)

# Description
Adds a new screen helper method to get the approximate position of units on the board.
This is the first step in adding item logic. I haven't done more yet since I think it's better to PR this step-by-step.

I've done my best to show what the steps in OpenCV are doing:
![showcase](https://github.com/Kyrluckechuck/TFT-Bot/assets/60011425/6e79392b-8806-4af1-b4c3-affbfa4e54c7)
In text-form:
1. Take a screenshot and convert the colors to an HSV range we can work with
2. Remove everything except certain green colors in the image (as a mask, that's why black&white)
3. Remove noise (small / random pixels)
4. Expand the left-over pixels
5. Blur the pixels so they get merged together
6. Group them as a rectangle

Based on those groups, the actual Y position on the board is calculated.
This is what the debug line should look like:
```
2023-05-27 02:36:22.160 | DEBUG    | __main__:main_game_loop:540 - Board positions: [Coordinates(position_x=1373, position_y=672), Coordinates(position_x=1236, position_y=672), Coordinates(position_x=873, position_y=596), Coordinates(position_x=969, position_y=515), Coordinates(position_x=846, position_y=515), Coordinates(position_x=1267, position_y=446), Coordinates(position_x=1149, position_y=446), Coordinates(position_x=1028, position_y=446)]
```

Visualized, the blue box is a 50x50 rectangle around each coordinate
![coordinates](https://github.com/Kyrluckechuck/TFT-Bot/assets/60011425/74571e4c-d034-4d8f-8c3a-bf7dba9b653a)

I have the math ready to center the box on the x-axis of the actual "square" of the board as well, but it's good enough like that I think, so we can skip calculating it.

# Notes
We shouldn't need to consider offsets here, since it's raw pixel coordinates in the screenshot. However, we do need to consider window offsets once we want to move the mouse to the coordinates.

Additional commits:
- Gives the client more time to load after games
- Removes the UAC flag from the installer. The `.exe` being ran as administrator is the only difference to running from source (besides the data folder), so I'm hoping that's one of the things we can stop doing to increase security as well.