### PR TITLE
Update League Client To Use ClientServices Launcher, API Tweaks

### DIFF
--- a/tft.py
+++ b/tft.py
@@ -128,7 +128,10 @@ def restart_league_client() -> None:
         wait_for_internet()
         time.sleep(1)
 
-    subprocess.run(CONSTANTS["executables"]["league"]["client"], check=True)
+    executable_with_launch_args = [CONSTANTS["executables"]["riot_client"]["client_services"]] + CONSTANTS[
+        "executables"
+    ]["riot_client"]["league_launch_arguments"]
+    subprocess.run(args=executable_with_launch_args, check=True)
     time.sleep(3)
     if not LCU_INTEGRATION.connect_to_lcu(wait_for_availability=True):
         restart_league_client()
@@ -696,6 +699,18 @@ def update_league_constants(league_install_location: str) -> None:
     ] = rf"{league_install_location}{CONSTANTS['executables']['league']['game_base']}"
 
 
+def update_riot_client_constants(riot_client_install_location: str) -> None:
+    """Update Riot Client executable constants
+
+    Args:
+        riot_client_install_location (str): The determined location for the executables
+    """
+    logger.debug(rf"Updating riot client install location to {riot_client_install_location}")
+    CONSTANTS["executables"]["riot_client"][
+        "client_services"
+    ] = rf"{riot_client_install_location}{CONSTANTS['executables']['riot_client']['client_services']}"
+
+
 def setup_hotkeys() -> None:
     """Setup hotkey listeners"""
     keyboard.add_hotkey("alt+p", lambda: toggle_pause())  # pylint: disable=unnecessary-lambda
@@ -884,6 +899,8 @@ def main():
         logger.warning("League client is not open, attempting to start it")
         league_directory = system_helpers.determine_league_install_location()
         update_league_constants(league_directory)
+        riot_client_directory = system_helpers.determine_riot_client_install_location()
+        update_riot_client_constants(riot_client_directory)
         restart_league_client()
     elif not LCU_INTEGRATION.connect_to_lcu():
         restart_league_client()

--- a/tft_bot/config.py
+++ b/tft_bot/config.py
@@ -128,7 +128,7 @@ def forfeit_early() -> bool:
     return _SELF.get("forfeit_early", False)
 
 
-def get_override_install_location() -> str | None:
+def get_override_install_location(app: str) -> str | None:
     """
     Get the value of the override_install_location setting in the config.
 
@@ -136,7 +136,7 @@ def get_override_install_location() -> str | None:
         An optional string containing the user-defined install location.
 
     """
-    return _SELF.get("override_install_location") or None
+    return _SELF.get(f"override_install_location_{app}") or None
 
 
 def get_wanted_traits() -> list[str]:

--- a/tft_bot/constants.py
+++ b/tft_bot/constants.py
@@ -11,6 +11,10 @@ CONSTANTS = {
             "client_ux": r"\LeagueClientUx.exe",
             "game": r"\Game\League of Legends.exe",
         },
+        "riot_client": {
+            "client_services": r"\RiotClientServices.exe",
+            "league_launch_arguments": ["--launch-product=league_of_legends", "--launch-patchline=live"],
+        },
     },
     "window_titles": {
         "game": "League of Legends (TM) Client",
@@ -20,7 +24,8 @@ CONSTANTS = {
         "client": "LeagueClient.exe",
         "client_ux": "LeagueClientUx.exe",
         "game": "League of Legends.exe",
-        "rito_client": "RiotClientServices.exe",
+        "rito_client": "RiotClientUx.exe",
+        "rito_client_service": "RiotClientServices.exe",
     },
     "client": {
         "messages": {
@@ -148,4 +153,5 @@ league_processes = [
     CONSTANTS["processes"]["client_ux"],
     CONSTANTS["processes"]["game"],
     CONSTANTS["processes"]["rito_client"],
+    CONSTANTS["processes"]["rito_client_service"],
 ]

--- a/tft_bot/league_api/league_api_integration.py
+++ b/tft_bot/league_api/league_api_integration.py
@@ -241,10 +241,15 @@ class LCUIntegration:
             self._session.get, url=f"{self._url}/lol-lobby/v2/lobby/matchmaking/search-state"
         )
 
-        return get_queue_response.status_code is not None and get_queue_response.json()["searchState"] in {
-            "Searching",
-            "Found",
-        }
+        return (
+            get_queue_response is not None
+            and get_queue_response.status_code is not None
+            and get_queue_response.json()["searchState"]
+            in {
+                "Searching",
+                "Found",
+            }
+        )
 
     def found_queue(self) -> bool:
         """

--- a/tft_bot/resources/config.yaml
+++ b/tft_bot/resources/config.yaml
@@ -64,10 +64,13 @@ timeouts:
 # 1. You're initially starting the bot while the League Client is closed
 # 2. You want the bot to start the League Client for you
 # 3. The bot is unable to determine the League installation path by itself
-override_install_location: ''
+override_install_location_league_client: ''
+
+# Same as above, but for the Riot Client
+override_install_location_riot_client: ''
 
 # Changing these below values manually can potentially break the bot, so don't!
 # Version of the YAML.
-version: 6
+version: 7
 # Version of the TFT set.
-set: 9
+set: 9.5


### PR DESCRIPTION
![](https://media.giphy.com/media/Fn7EouKtFLHXhWKgFI/giphy.gif)


## Description
Some long overdue updates since I haven't been using this for the last while, but have been for the last couple event passes.

- Updates the league app to launch via the `RiotClientServices.exe` launch call, the same way that the `League of Legends` shortcut would launch the game. This should fix most scenarios which would open either the Riot Client or other sub-clients and launches League directly.
  - As part of this, we now try to parse out the Riot Client install location as well. Since there is no obvious registry entries for it (at least that I could find), I opted to parse it out of the League client uninstaller path.
    - If this eventually stops working and another path / reliable detection method isn't added, we may just swap to hard-coding this and making it so the bot user has to specify the override if they want it to work on non-standard install locations
- On that note, I updated what the league & riot install override settings are since there are two now
- Fixed edge case in Status API where the status would not be returned as expected and would then crash out instead of following the abort flow like it should