### PR TITLE
Added support for Deceive

### DIFF
--- a/tft.py
+++ b/tft.py
@@ -115,6 +115,7 @@ def kill_process(process_executable: str, force: bool = True) -> subprocess.Comp
         text=True,
     )
 
+
 def launch_league_client(deceive_config: bool) -> None:
     """
     Launches the client
@@ -125,20 +126,20 @@ def launch_league_client(deceive_config: bool) -> None:
     if deceive_config:
         location = config.get_install_location_deceive()
         if location is None:
-            logger.warning("Deceive is enabled in config.yaml, but no path was given! The bot will attempt to find the .exe on its own")
+            logger.warning("Deceive is enabled in config.yaml, but no path was given! The bot will attempt to find the .exe on its own")    # pylint: disable=line-too-long
             location = system_helpers.determine_deceive_install_location()
             if location is None:
-                logger.error("Could not determine Deceive location. Please manually add the location in output/config.yaml")
+                logger.error("Could not determine Deceive location. Please manually add the location in output/config.yaml")    # pylint: disable=line-too-long
                 logger.warning("Bot will now continue without Deceive")
                 config.update_deceive_config(update=False)
                 launch_league_client(deceive_config=False)
                 return
-            else:
-                logger.info(f"Found Deceive at: {location}")
+
+            logger.info(f"Found Deceive at: {location}")
         else:
             logger.debug(f"Using deceive with the given path: {location}")
 
-        subprocess.Popen(
+        subprocess.Popen(   # pylint: disable=consider-using-with
             location,
             stdin=None,
             stdout=None,
@@ -160,6 +161,7 @@ def launch_league_client(deceive_config: bool) -> None:
             close_fds=True,
             creationflags=DETACHED_PROCESS,
         )
+
 
 def restart_league_client() -> None:
     """Restarts the league client."""
@@ -919,7 +921,8 @@ def main():
     logger.info("===== TFT Bot Started =====")
     logger.info(f"Bot will only display messages at severity level {log_level}.")
     logger.info(f"Bot will {'' if config.forfeit_early() else 'NOT '}surrender early.")
-    logger.info(f"Bot will {'' if config.get_deceive_config() else 'NOT '}use Deceive" + (f" with location: {config.get_install_location_deceive()}." if config.get_deceive_config() else "."))
+    logger.info(f"Bot will {'' if config.get_deceive_config() else 'NOT '}use Deceive" +
+    (f" with location: {config.get_install_location_deceive()}." if config.get_deceive_config() else "."))
 
     absolute_storage_path = os.path.abspath(storage_path)
     if not os.access(absolute_storage_path, os.W_OK):

--- a/tft.py
+++ b/tft.py
@@ -123,30 +123,37 @@ def restart_league_client() -> None:
         logger.debug(f"Killing {process_to_kill}")
         result = kill_process(process_to_kill)
         parse_task_kill_result(result)
-    time.sleep(1)
+    time.sleep(5)
 
     if not system_helpers.internet():
         wait_for_internet()
         time.sleep(1)
 
     if config.get_deceive_config() and config.get_install_location_deceive() is not None:
-        executable_with_launch_args = config.get_install_location_deceive() + CONSTANTS[
-            "executables"
-        ]["riot_client"]["league_launch_arguments"]
+        executable = config.get_install_location_deceive()
         logger.debug(f"Using deceive with the following path: {config.get_install_location_deceive()}")
+
+        subprocess.Popen(
+            executable,
+            stdin=None,
+            stdout=None,
+            stderr=None,
+            close_fds=True,
+            creationflags=DETACHED_PROCESS,
+        )
     else:
         executable_with_launch_args = [CONSTANTS["executables"]["riot_client"]["client_services"]] + CONSTANTS[
             "executables"
         ]["riot_client"]["league_launch_arguments"]
 
-    subprocess.Popen(  # pylint: disable=consider-using-with
-        args=executable_with_launch_args,
-        stdin=None,
-        stdout=None,
-        stderr=None,
-        close_fds=True,
-        creationflags=DETACHED_PROCESS,
-    )
+        subprocess.Popen(  # pylint: disable=consider-using-with
+            args=executable_with_launch_args,
+            stdin=None,
+            stdout=None,
+            stderr=None,
+            close_fds=True,
+            creationflags=DETACHED_PROCESS,
+        )
     time.sleep(3)
     if not LCU_INTEGRATION.connect_to_lcu(wait_for_availability=True):
         restart_league_client()
@@ -890,6 +897,7 @@ def main():
     logger.info("===== TFT Bot Started =====")
     logger.info(f"Bot will only display messages at severity level {log_level}.")
     logger.info(f"Bot will {'' if config.forfeit_early() else 'NOT '}surrender early.")
+    logger.info(f"Bot will {'' if config.get_deceive_config() else 'NOT '}use Deceive" + f" with location: {config.get_install_location_deceive()}" if config.get_deceive_config() else "")
 
     absolute_storage_path = os.path.abspath(storage_path)
     if not os.access(absolute_storage_path, os.W_OK):

--- a/tft.py
+++ b/tft.py
@@ -129,11 +129,11 @@ def restart_league_client() -> None:
         wait_for_internet()
         time.sleep(1)
 
-    if get_deceive_config() and get_install_location_deceive() != '':
-        executable_with_launch_args = get_install_location_deceive() + CONSTANTS[
+    if config.get_deceive_config() and config.get_install_location_deceive() != '':
+        executable_with_launch_args = config.get_install_location_deceive() + CONSTANTS[
             "executables"
         ]["riot_client"]["league_launch_arguments"]
-        logger.debug(f"Using deceive with the following path: {get_install_location_deceive()}")
+        logger.debug(f"Using deceive with the following path: {config.get_install_location_deceive()}")
     else:
         executable_with_launch_args = [CONSTANTS["executables"]["riot_client"]["client_services"]] + CONSTANTS[
             "executables"

--- a/tft.py
+++ b/tft.py
@@ -920,7 +920,7 @@ def main():
     logger.info("===== TFT Bot Started =====")
     logger.info(f"Bot will only display messages at severity level {log_level}.")
     logger.info(f"Bot will {'' if config.forfeit_early() else 'NOT '}surrender early.")
-    logger.info(f"Bot will {'' if config.get_deceive_config() else 'NOT '}use Deceive" + f" with location: {config.get_install_location_deceive()}" if config.get_deceive_config() else "")
+    logger.info(f"Bot will {'' if config.get_deceive_config() else 'NOT '}use Deceive" + (f" with location: {config.get_install_location_deceive()}." if config.get_deceive_config() else "."))
 
     absolute_storage_path = os.path.abspath(storage_path)
     if not os.access(absolute_storage_path, os.W_OK):

--- a/tft.py
+++ b/tft.py
@@ -126,41 +126,36 @@ def launch_league_client(deceive_config: bool) -> None:
     if deceive_config:
         location = config.get_install_location_deceive()
         if location is None:
-            logger.warning("Deceive is enabled in config.yaml, but no path was given! The bot will attempt to find the .exe on its own")    # pylint: disable=line-too-long
+            logger.warning("Deceive is enabled in config.yaml, but no path was given!")
+            logger.warning("The bot will attempt to find the .exe on its own")
             location = system_helpers.determine_deceive_install_location()
             if location is None:
-                logger.error("Could not determine Deceive location. Please manually add the location in output/config.yaml")    # pylint: disable=line-too-long
+                logger.error("Could not determine Deceive location. Please manually add the path in output/config.yaml")
                 logger.warning("Bot will now continue without Deceive")
                 config.update_deceive_config(update=False)
                 launch_league_client(deceive_config=False)
                 return
-
             logger.info(f"Found Deceive at: {location}")
+
         else:
             logger.debug(f"Using deceive with the given path: {location}")
 
-        subprocess.Popen(   # pylint: disable=consider-using-with
-            location,
-            stdin=None,
-            stdout=None,
-            stderr=None,
-            close_fds=True,
-            creationflags=DETACHED_PROCESS,
-        )
+        executable_with_launch_args = location
+
     else:
         executable_with_launch_args = [CONSTANTS["executables"]["riot_client"]["client_services"]] + CONSTANTS[
             "executables"
         ]["riot_client"]["league_launch_arguments"]
         logger.debug("Opening League through the riot client")
 
-        subprocess.Popen(  # pylint: disable=consider-using-with
-            args=executable_with_launch_args,
-            stdin=None,
-            stdout=None,
-            stderr=None,
-            close_fds=True,
-            creationflags=DETACHED_PROCESS,
-        )
+    subprocess.Popen(  # pylint: disable=consider-using-with
+        args=executable_with_launch_args,
+        stdin=None,
+        stdout=None,
+        stderr=None,
+        close_fds=True,
+        creationflags=DETACHED_PROCESS,
+    )
 
 
 def restart_league_client() -> None:

--- a/tft.py
+++ b/tft.py
@@ -2,7 +2,6 @@
 The main TFT Bot code
 """
 from datetime import datetime
-from pathlib import Path
 import os
 import random
 import subprocess

--- a/tft.py
+++ b/tft.py
@@ -130,11 +130,10 @@ def restart_league_client() -> None:
         time.sleep(1)
 
     if config.get_deceive_config() and config.get_install_location_deceive() is not None:
-        executable = config.get_install_location_deceive()
         logger.debug(f"Using deceive with the following path: {config.get_install_location_deceive()}")
 
         subprocess.Popen(
-            executable,
+            config.get_install_location_deceive(),
             stdin=None,
             stdout=None,
             stderr=None,
@@ -145,6 +144,7 @@ def restart_league_client() -> None:
         executable_with_launch_args = [CONSTANTS["executables"]["riot_client"]["client_services"]] + CONSTANTS[
             "executables"
         ]["riot_client"]["league_launch_arguments"]
+        logger.debug("Opening League through the riot client")
 
         subprocess.Popen(  # pylint: disable=consider-using-with
             args=executable_with_launch_args,

--- a/tft.py
+++ b/tft.py
@@ -916,8 +916,10 @@ def main():
     logger.info("===== TFT Bot Started =====")
     logger.info(f"Bot will only display messages at severity level {log_level}.")
     logger.info(f"Bot will {'' if config.forfeit_early() else 'NOT '}surrender early.")
-    logger.info(f"Bot will {'' if config.get_deceive_config() else 'NOT '}use Deceive" +
-                (f" with location: {config.get_install_location_deceive()}." if config.get_deceive_config() else "."))
+    logger.info(
+        f"Bot will {'' if config.get_deceive_config() else 'NOT '}use Deceive"
+        + (f" with location: {config.get_install_location_deceive()}." if config.get_deceive_config() else ".")
+    )
 
     absolute_storage_path = os.path.abspath(storage_path)
     if not os.access(absolute_storage_path, os.W_OK):

--- a/tft.py
+++ b/tft.py
@@ -121,7 +121,7 @@ def launch_league_client(deceive_config: bool) -> None:
     Launches the client
 
     Args:
-    deceive_config: Whether to open the client through Riot or through Deceive
+        deceive_config: Whether to open the client through Riot or through Deceive
     """
     if deceive_config:
         location = config.get_install_location_deceive()
@@ -922,7 +922,7 @@ def main():
     logger.info(f"Bot will only display messages at severity level {log_level}.")
     logger.info(f"Bot will {'' if config.forfeit_early() else 'NOT '}surrender early.")
     logger.info(f"Bot will {'' if config.get_deceive_config() else 'NOT '}use Deceive" +
-    (f" with location: {config.get_install_location_deceive()}." if config.get_deceive_config() else "."))
+                (f" with location: {config.get_install_location_deceive()}." if config.get_deceive_config() else "."))
 
     absolute_storage_path = os.path.abspath(storage_path)
     if not os.access(absolute_storage_path, os.W_OK):

--- a/tft.py
+++ b/tft.py
@@ -129,7 +129,7 @@ def restart_league_client() -> None:
         wait_for_internet()
         time.sleep(1)
 
-    if config.get_deceive_config() and config.get_install_location_deceive() != '':
+    if config.get_deceive_config() and config.get_install_location_deceive() is not None:
         executable_with_launch_args = config.get_install_location_deceive() + CONSTANTS[
             "executables"
         ]["riot_client"]["league_launch_arguments"]

--- a/tft.py
+++ b/tft.py
@@ -129,9 +129,16 @@ def restart_league_client() -> None:
         wait_for_internet()
         time.sleep(1)
 
-    executable_with_launch_args = [CONSTANTS["executables"]["riot_client"]["client_services"]] + CONSTANTS[
-        "executables"
-    ]["riot_client"]["league_launch_arguments"]
+    if get_deceive_config() and get_install_location_deceive() != '':
+        executable_with_launch_args = get_install_location_deceive() + CONSTANTS[
+            "executables"
+        ]["riot_client"]["league_launch_arguments"]
+        logger.debug(f"Using deceive with the following path: {get_install_location_deceive()}")
+    else:
+        executable_with_launch_args = [CONSTANTS["executables"]["riot_client"]["client_services"]] + CONSTANTS[
+            "executables"
+        ]["riot_client"]["league_launch_arguments"]
+
     subprocess.Popen(  # pylint: disable=consider-using-with
         args=executable_with_launch_args,
         stdin=None,

--- a/tft.py
+++ b/tft.py
@@ -135,7 +135,7 @@ def launch_league_client(deceive_config: bool) -> None:
                 launch_league_client(deceive_config=False)
                 return
             else:
-                logger.warning(f"Found Deceive at: {location}")
+                logger.info(f"Found Deceive at: {location}")
         else:
             logger.debug(f"Using deceive with the given path: {location}")
 

--- a/tft.py
+++ b/tft.py
@@ -2,6 +2,7 @@
 The main TFT Bot code
 """
 from datetime import datetime
+from pathlib import Path
 import os
 import random
 import subprocess
@@ -115,25 +116,31 @@ def kill_process(process_executable: str, force: bool = True) -> subprocess.Comp
         text=True,
     )
 
+def launch_league_client(deceive_config: bool) -> None:
+    """
+    Launches the client
 
-def restart_league_client() -> None:
-    """Restarts the league client."""
-    logger.debug("Killing League Processes!")
-    for process_to_kill in league_processes:
-        logger.debug(f"Killing {process_to_kill}")
-        result = kill_process(process_to_kill)
-        parse_task_kill_result(result)
-    time.sleep(5)
-
-    if not system_helpers.internet():
-        wait_for_internet()
-        time.sleep(1)
-
-    if config.get_deceive_config() and config.get_install_location_deceive() is not None:
-        logger.debug(f"Using deceive with the following path: {config.get_install_location_deceive()}")
+    Args:
+    deceive_config: Whether to open the client through Riot or through Deceive
+    """
+    if deceive_config:
+        location = config.get_install_location_deceive()
+        if location is None:
+            logger.warning("Deceive is enabled in config.yaml, but no path was given! The bot will attempt to find the .exe on its own")
+            location = system_helpers.determine_deceive_install_location()
+            if location is None:
+                logger.error("Could not determine Deceive location. Please manually add the location in output/config.yaml")
+                logger.warning("Bot will now continue without Deceive")
+                config.update_deceive_config(update=False)
+                launch_league_client(deceive_config=False)
+                return
+            else:
+                logger.warning(f"Found Deceive at: {location}")
+        else:
+            logger.debug(f"Using deceive with the given path: {location}")
 
         subprocess.Popen(
-            config.get_install_location_deceive(),
+            location,
             stdin=None,
             stdout=None,
             stderr=None,
@@ -154,6 +161,22 @@ def restart_league_client() -> None:
             close_fds=True,
             creationflags=DETACHED_PROCESS,
         )
+
+def restart_league_client() -> None:
+    """Restarts the league client."""
+    logger.debug("Killing League Processes!")
+    for process_to_kill in league_processes:
+        logger.debug(f"Killing {process_to_kill}")
+        result = kill_process(process_to_kill)
+        parse_task_kill_result(result)
+    time.sleep(5)
+
+    if not system_helpers.internet():
+        wait_for_internet()
+        time.sleep(1)
+
+    launch_league_client(deceive_config=config.get_deceive_config())
+
     time.sleep(3)
     if not LCU_INTEGRATION.connect_to_lcu(wait_for_availability=True):
         restart_league_client()

--- a/tft_bot/config.py
+++ b/tft_bot/config.py
@@ -216,6 +216,7 @@ def get_economy_mode(system_helpers) -> EconomyMode:
                 wanted_traits=wanted_traits, prioritized_order=prioritized_order, tesseract_location=tesseract_location
             )
 
+
 def get_deceive_config() -> bool:
     """
     Checks if the bot should use Deceive.
@@ -225,6 +226,7 @@ def get_deceive_config() -> bool:
     """
     return _SELF.get("use_deceive", False)
 
+
 def get_install_location_deceive() -> str | None:
     """
     Gets the path of Deceive.exe.
@@ -233,6 +235,7 @@ def get_install_location_deceive() -> str | None:
     String containing path or None if empty.
     """
     return _SELF.get("install_location_deceive") or None
+
 
 def update_deceive_config(update: bool) -> None:
     """

--- a/tft_bot/config.py
+++ b/tft_bot/config.py
@@ -232,7 +232,7 @@ def get_install_location_deceive() -> str | None:
     Gets the path of Deceive.exe.
 
     Returns:
-    String containing path or None if empty.
+        String containing path or None if empty.
     """
     return _SELF.get("install_location_deceive") or None
 
@@ -242,6 +242,6 @@ def update_deceive_config(update: bool) -> None:
     Updates whether the bot should use Deceive or not.
 
     Args:
-    update: The new bool that should be used henceforth
+        update: The new bool that should be used henceforth
     """
     _SELF["use_deceive"] = update

--- a/tft_bot/config.py
+++ b/tft_bot/config.py
@@ -225,11 +225,11 @@ def get_deceive_config() -> bool:
     """
     return _SELF.get("use_deceive", False)
 
-def get_install_location_deceive() -> str:
+def get_install_location_deceive() -> str | None:
     """
     Get the path of Deceive.exe.
 
     Returns:
     String containing path.
     """
-    return _SELF.get("install_location_deceive", '')
+    return _SELF.get("install_location_deceive") or None

--- a/tft_bot/config.py
+++ b/tft_bot/config.py
@@ -233,3 +233,12 @@ def get_install_location_deceive() -> str | None:
     String containing path.
     """
     return _SELF.get("install_location_deceive") or None
+
+def update_deceive_config(update: bool) -> None:
+    """
+    Updates whether the bot should use Deceive or not.
+
+    Args:
+    update: The new bool that should be used henceforth
+    """
+    _SELF["use_deceive"] = update

--- a/tft_bot/config.py
+++ b/tft_bot/config.py
@@ -215,3 +215,21 @@ def get_economy_mode(system_helpers) -> EconomyMode:
             return OCRStandardEconomyMode(
                 wanted_traits=wanted_traits, prioritized_order=prioritized_order, tesseract_location=tesseract_location
             )
+
+def get_deceive_config() -> bool:
+    """
+    Check if we want to use deceive.
+
+    Returns:
+        True or False.
+    """
+    return _SELF.get("use_deceive", False)
+
+def get_install_location_deceive() -> str:
+    """
+    Get the path of Deceive.exe.
+
+    Returns:
+    String containing path.
+    """
+    return _SELF.get("install_location_deceive", '')

--- a/tft_bot/config.py
+++ b/tft_bot/config.py
@@ -218,7 +218,7 @@ def get_economy_mode(system_helpers) -> EconomyMode:
 
 def get_deceive_config() -> bool:
     """
-    Check if we want to use deceive.
+    Checks if the bot should use Deceive.
 
     Returns:
         True or False.
@@ -227,10 +227,10 @@ def get_deceive_config() -> bool:
 
 def get_install_location_deceive() -> str | None:
     """
-    Get the path of Deceive.exe.
+    Gets the path of Deceive.exe.
 
     Returns:
-    String containing path.
+    String containing path or None if empty.
     """
     return _SELF.get("install_location_deceive") or None
 

--- a/tft_bot/constants.py
+++ b/tft_bot/constants.py
@@ -23,6 +23,7 @@ CONSTANTS = {
     "processes": {
         "client": "LeagueClient.exe",
         "client_ux": "LeagueClientUx.exe",
+        "deceive": "Deceive.exe",
         "game": "League of Legends.exe",
         "rito_client": "RiotClientUx.exe",
         "rito_client_service": "RiotClientServices.exe",
@@ -151,6 +152,7 @@ message_exit_buttons = [
 league_processes = [
     CONSTANTS["processes"]["client"],
     CONSTANTS["processes"]["client_ux"],
+    CONSTANTS["processes"]["deceive"],
     CONSTANTS["processes"]["game"],
     CONSTANTS["processes"]["rito_client"],
     CONSTANTS["processes"]["rito_client_service"],

--- a/tft_bot/constants.py
+++ b/tft_bot/constants.py
@@ -15,9 +15,6 @@ CONSTANTS = {
             "client_services": r"\RiotClientServices.exe",
             "league_launch_arguments": ["--launch-product=league_of_legends", "--launch-patchline=live"],
         },
-        "deceive": {
-            "deceive_launch_arguments": ["--launch-product=deceive"]
-        }
     },
     "window_titles": {
         "game": "League of Legends (TM) Client",

--- a/tft_bot/constants.py
+++ b/tft_bot/constants.py
@@ -15,6 +15,9 @@ CONSTANTS = {
             "client_services": r"\RiotClientServices.exe",
             "league_launch_arguments": ["--launch-product=league_of_legends", "--launch-patchline=live"],
         },
+        "deceive": {
+            "deceive_launch_arguments": ["--launch-product=deceive"]
+        }
     },
     "window_titles": {
         "game": "League of Legends (TM) Client",

--- a/tft_bot/helpers/system_helpers.py
+++ b/tft_bot/helpers/system_helpers.py
@@ -249,20 +249,27 @@ def determine_deceive_install_location() -> str | None:
     If successful, a string of the determined location, if not, None.
     """
     # Check downloads folder first. Might just find it
-    downloads_path = str(pathlib.Path.home() / "Downloads")
-    for root, dirs, files in os.walk(downloads_path):
-        for file in files:
-            if "Deceive.exe" in file:
-                logger.debug("Found Deceive in Downloads folder")
-                return os.path.join(root, file)
+    # downloads_path = str(pathlib.Path.home() / "Downloads")
+    # for root, dirs, files in os.walk(downloads_path):
+    #     for file in files:
+    #         if "Deceive.exe" in file:
+    #             logger.debug("Found Deceive in Downloads folder")
+    #             return os.path.join(root, file)
     
     # Search registry now
     key_to_read = r"SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Compatibility Assistant\Store"
     k = winreg.OpenKey(winreg.HKEY_CURRENT_USER, key_to_read, 0, winreg.KEY_READ)
 
+    results = []
     for i in range(0, winreg.QueryInfoKey(k)[1]):
         if "Deceive.exe" in winreg.EnumValue(k, i)[0]:
+            results.append(winreg.EnumValue(k, i)[0])
+
+    # Registry actually never deletes entries, therefore if Deceive ever gets moved, there will be multiple entries.
+    # Therefore we need to check all paths and find the real one
+    for result in results:
+        if os.path.isfile(result):
             logger.debug("Found Deceive through registry")
-            return winreg.EnumValue(k, i)[0]
+            return result
 
     return None

--- a/tft_bot/helpers/system_helpers.py
+++ b/tft_bot/helpers/system_helpers.py
@@ -249,12 +249,12 @@ def determine_deceive_install_location() -> str | None:
     If successful, a string of the determined location, if not, None.
     """
     # Check downloads folder first. Might just find it
-    # downloads_path = str(pathlib.Path.home() / "Downloads")
-    # for root, dirs, files in os.walk(downloads_path):
-    #     for file in files:
-    #         if "Deceive.exe" in file:
-    #             logger.debug("Found Deceive in Downloads folder")
-    #             return os.path.join(root, file)
+    downloads_path = str(pathlib.Path.home() / "Downloads")
+    for root, dirs, files in os.walk(downloads_path):
+        for file in files:
+            if "Deceive.exe" in file:
+                logger.debug("Found Deceive in Downloads folder")
+                return os.path.join(root, file)
     
     # Search registry now
     key_to_read = r"SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Compatibility Assistant\Store"

--- a/tft_bot/helpers/system_helpers.py
+++ b/tft_bot/helpers/system_helpers.py
@@ -247,7 +247,7 @@ def determine_deceive_install_location() -> str | None:
     Tries to determine the install location of Deceive.
 
     Returns:
-    If successful, a string of the determined location, if not, None.
+        If successful, a string of the determined location, if not, None.
     """
     # Check downloads folder first. Might just find it
     downloads_path = str(pathlib.Path.home() / "Downloads")

--- a/tft_bot/helpers/system_helpers.py
+++ b/tft_bot/helpers/system_helpers.py
@@ -251,7 +251,7 @@ def determine_deceive_install_location() -> str | None:
     """
     # Check downloads folder first. Might just find it
     downloads_path = str(pathlib.Path.home() / "Downloads")
-    for root, dirs, files in os.walk(downloads_path):   # pylint: disable=unused-variable
+    for root, dirs, files in os.walk(downloads_path):  # pylint: disable=unused-variable
         for file in files:
             if "Deceive.exe" in file:
                 logger.debug("Found Deceive in Downloads folder")

--- a/tft_bot/helpers/system_helpers.py
+++ b/tft_bot/helpers/system_helpers.py
@@ -240,3 +240,29 @@ def determine_tesseract_ocr_install_location() -> str:
     logger.debug(f"Tesseract-OCR location determined to be: {tesseract_ocr_path}")
 
     return tesseract_ocr_path
+
+def determine_deceive_install_location() -> str | None:
+    """
+    Tries to determine the install location of Deceive.
+
+    Returns:
+    If successful, a string of the determined location, if not, None.
+    """
+    # Check downloads folder first. Might just find it
+    downloads_path = str(pathlib.Path.home() / "Downloads")
+    for root, dirs, files in os.walk(downloads_path):
+        for file in files:
+            if "Deceive" in file:
+                logger.debug("Found Deceive in Downloads folder")
+                return os.path.join(root, file)
+    
+    # Search registry now
+    key_to_read = r"SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Compatibility Assistant\Store"
+    k = winreg.OpenKey(winreg.HKEY_CURRENT_USER, key_to_read, 0, winreg.KEY_READ)
+
+    for i in range(0, winreg.QueryInfoKey(k)[1]):
+        if "Deceive" in winreg.EnumValue(k, i)[0]:
+            logger.Debug("Found Deceive through registry")
+            return winreg.EnumValue(k, i)[0]
+
+    return None

--- a/tft_bot/helpers/system_helpers.py
+++ b/tft_bot/helpers/system_helpers.py
@@ -241,6 +241,7 @@ def determine_tesseract_ocr_install_location() -> str:
 
     return tesseract_ocr_path
 
+
 def determine_deceive_install_location() -> str | None:
     """
     Tries to determine the install location of Deceive.
@@ -250,12 +251,12 @@ def determine_deceive_install_location() -> str | None:
     """
     # Check downloads folder first. Might just find it
     downloads_path = str(pathlib.Path.home() / "Downloads")
-    for root, dirs, files in os.walk(downloads_path):
+    for root, dirs, files in os.walk(downloads_path):   # pylint: disable=unused-variable
         for file in files:
             if "Deceive.exe" in file:
                 logger.debug("Found Deceive in Downloads folder")
                 return os.path.join(root, file)
-    
+
     # Search registry now
     key_to_read = r"SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Compatibility Assistant\Store"
     k = winreg.OpenKey(winreg.HKEY_CURRENT_USER, key_to_read, 0, winreg.KEY_READ)

--- a/tft_bot/helpers/system_helpers.py
+++ b/tft_bot/helpers/system_helpers.py
@@ -252,7 +252,7 @@ def determine_deceive_install_location() -> str | None:
     downloads_path = str(pathlib.Path.home() / "Downloads")
     for root, dirs, files in os.walk(downloads_path):
         for file in files:
-            if "Deceive" in file:
+            if "Deceive.exe" in file:
                 logger.debug("Found Deceive in Downloads folder")
                 return os.path.join(root, file)
     
@@ -261,8 +261,8 @@ def determine_deceive_install_location() -> str | None:
     k = winreg.OpenKey(winreg.HKEY_CURRENT_USER, key_to_read, 0, winreg.KEY_READ)
 
     for i in range(0, winreg.QueryInfoKey(k)[1]):
-        if "Deceive" in winreg.EnumValue(k, i)[0]:
-            logger.Debug("Found Deceive through registry")
+        if "Deceive.exe" in winreg.EnumValue(k, i)[0]:
+            logger.debug("Found Deceive through registry")
             return winreg.EnumValue(k, i)[0]
 
     return None

--- a/tft_bot/resources/config.yaml
+++ b/tft_bot/resources/config.yaml
@@ -75,7 +75,7 @@ override_install_location_riot_client: ''
 # IMPORTANT: If you want the bot to use deceive, enable deceive to automatically choose League of Legends instead of asking you what you want to launch!
 # You can do this by opening deceive and then checking the box "remember my choice", then choosing League.
 use_deceive: false
-install_location_deceive: ''
+install_location_deceive: ""
 
 # Changing these below values manually can potentially break the bot, so don't!
 # Version of the YAML.

--- a/tft_bot/resources/config.yaml
+++ b/tft_bot/resources/config.yaml
@@ -69,13 +69,12 @@ override_install_location_league_client: ''
 # Same as above, but for the Riot Client
 override_install_location_riot_client: ''
 
-# By default, the bot only opens the Riot Client itself if something goes wrong. If you have Deceive installed and want to use it,
-# please set the following condition from 'false' to 'true'. Additionally, since this is not part of the game folder, 
-# you need to manually define its install location right below.
-# IMPORTANT: If you want the bot to use deceive, enable deceive to automatically choose League of Legends instead of asking you what you want to launch!
-# You can do this by opening deceive and then checking the box "remember my choice", then choosing League.
+# If you want the bot to open League through Deceive instead of the Riot Client, please enable the option right below.
+# The bot will automatically search for the install location of Deceive when need, but it is still recommended to manually input it.
+# IMPORTANT: If you want the bot to use Deceive, you need to make sure that Deceive automatically runs League of Legends when executed.
+# You can enable this by opening Deceive and checking the box "Remember my decision", then clicking on League.
 use_deceive: false
-install_location_deceive: ""
+install_location_deceive: ''
 
 # Changing these below values manually can potentially break the bot, so don't!
 # Version of the YAML.

--- a/tft_bot/resources/config.yaml
+++ b/tft_bot/resources/config.yaml
@@ -69,6 +69,14 @@ override_install_location_league_client: ''
 # Same as above, but for the Riot Client
 override_install_location_riot_client: ''
 
+# By default, the bot only opens the Riot Client itself if something goes wrong. If you have Deceive installed and want to use it,
+# please set the following condition from 'false' to 'true'. Additionally, since this is not part of the game folder, 
+# you need to manually define its install location right below.
+# IMPORTANT: If you want the bot to use deceive, enable deceive to automatically choose League of Legends instead of asking you what you want to launch!
+# You can do this by opening deceive and then checking the box "remember my choice", then choosing League.
+use_deceive: false
+install_location_deceive: ''
+
 # Changing these below values manually can potentially break the bot, so don't!
 # Version of the YAML.
 version: 7

--- a/tft_bot/resources/config.yaml
+++ b/tft_bot/resources/config.yaml
@@ -70,7 +70,7 @@ override_install_location_league_client: ''
 override_install_location_riot_client: ''
 
 # If you want the bot to open League through Deceive instead of the Riot Client, please enable the option right below.
-# The bot will automatically search for the install location of Deceive when need, but it is still recommended to manually input it.
+# The bot will automatically search for the install location of Deceive when needed, but it is still recommended to manually set it.
 # IMPORTANT: If you want the bot to use Deceive, you need to make sure that Deceive automatically runs League of Legends when executed.
 # You can enable this by opening Deceive and checking the box "Remember my decision", then clicking on League.
 use_deceive: false


### PR DESCRIPTION
### What is Deceive?
[Deceive](https://github.com/molenzwiebel/Deceive) is a program used to mask a player's online status while playing Riot games. It's decently popular and I use it myself, which is why I wrote this pull request.

### Additions
I've added two new settings to the config: **use_deceive** and **install_location_deceive**.

In **tft.py**, I've changed **restart_league_client()** to take these configs into consideration and it now runs the new function **launch_league_client()**, which does most of the job.

If no path to deceive is given, the bot will run **determine_deceive_install_location()**. This function first searches the Downloads folder, then looks through a specific registry key I've found to contain paths of .exe files. 
Something to note is that these entries don't get deleted, meaning if a file gets moved, the old entry for that file still exists despite becoming obsolete. Therefore the function finds all matches and then iterates through them until it finds a path pointing to an existing file.

If this still doesn't work, the config gets updated through **update_deceive_config()** to False and the bot won't try to open deceive again until restarted.

I've added logging and documentation to the places where it was needed.