### PR TITLE
Restart League Client If Disconnected And/or Sending Confusing Messages

### DIFF
--- a/tft.py
+++ b/tft.py
@@ -219,7 +219,7 @@ def queue() -> None:  # pylint: disable=too-many-branches
         if not PLAY_NEXT_GAME:
             evaluate_next_game_logic()
 
-        if LCU_INTEGRATION.client_connected():
+        if not LCU_INTEGRATION.client_connected():
             logger.warning("Client is not connected or sending confusing messages, restarting the client")
             restart_league_client()
             time.sleep(5)

--- a/tft.py
+++ b/tft.py
@@ -219,6 +219,12 @@ def queue() -> None:  # pylint: disable=too-many-branches
         if not PLAY_NEXT_GAME:
             evaluate_next_game_logic()
 
+        if LCU_INTEGRATION.client_connected():
+            logger.warning("Client is not connected or sending confusing messages, restarting the client")
+            restart_league_client()
+            time.sleep(5)
+            continue
+
         if LCU_INTEGRATION.session_expired():
             logger.warning("Our login session expired, restarting the client")
             restart_league_client()

--- a/tft.py
+++ b/tft.py
@@ -722,6 +722,7 @@ def update_riot_client_constants(riot_client_install_location: str) -> None:
         riot_client_install_location (str): The determined location for the executables
     """
     logger.debug(rf"Updating riot client install location to {riot_client_install_location}")
+    logger.debug(rf"{riot_client_install_location}{CONSTANTS['executables']['riot_client']['client_services']}")
     CONSTANTS["executables"]["riot_client"][
         "client_services"
     ] = rf"{riot_client_install_location}{CONSTANTS['executables']['riot_client']['client_services']}"


### PR DESCRIPTION
![](https://media.giphy.com/media/L2qukNXGjccyuAYd3W/giphy.gif)

## Description
If the league client closed in various circumstances, the client would infintitely try to re-create the tft lobby but fail since the client was not actually connected anymore.

This updates that logic to parse the session status message in order to detect if the client is no longer communicating properly